### PR TITLE
Add regex option.

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,3 +1,7 @@
+master (unreleased):
+  - Add an '--exclude' command line option to exclude files based on
+    regular expression.
+
 0.8.1 (2014-03-30):
   - Detect the declared encoding in Python 3.
   - Do not report redefinition of import in a local scope, if the


### PR DESCRIPTION
This is the code for https://bugs.launchpad.net/pyflakes/+bug/1311129

It adds a -e / --exclude command line for pyflakes script

Excludes are using a single regex.

Hope you will accept this patch and will reduce the need to duplicate api.py files in order to implement exclusion rules for each project.

Let me know if anything needs changes.

Thanks!
