### PR TITLE
Avoid crash on "return 2"

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -693,7 +693,11 @@ class Checker(object):
             raise RuntimeError("Got impossible expression context: %r" % (node.ctx,))
 
     def RETURN(self, node):
-        if node.value and not self.scope.returnValue:
+        if (
+            node.value and
+            hasattr(self.scope, 'returnValue') and
+            not self.scope.returnValue
+        ):
             self.scope.returnValue = node.value
         self.handleNode(node.value, node)
 

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -938,3 +938,7 @@ class TestUnusedAssignment(TestCase):
         def bar():
             yield from foo()
         ''', m.UndefinedName)
+
+    def test_returnOnly(self):
+        """Do not crash on lone "return"."""
+        self.flakes('return 2')


### PR DESCRIPTION
I wanted to report this months ago before the pyflakes repository got deleted.

Note that I'm not sure if this is the right way to do this. I guess `compile()` doesn't catch this because pyflakes is using `ast.PyCF_ONLY_AST` mode.
