### PR TITLE
Test mutable arguments in function definition.

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -752,6 +752,10 @@ class Checker(object):
         if is_py3_func:
             annotations.append(node.returns)
 
+        for default in defaults:
+            if isinstance(default, (ast.List, ast.Dict)):
+                self.report(messages.MutableArg, node)
+
         if len(set(args)) < len(args):
             for (idx, arg) in enumerate(args):
                 if arg in args[:idx]:

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -133,3 +133,10 @@ class ReturnWithArgsInsideGenerator(Message):
     Indicates a return statement with arguments inside a generator.
     """
     message = '\'return\' with argument inside generator'
+
+
+class MutableArg(Message):
+    """
+    Indicates that an argument default value value is mutable.
+    """
+    message = 'mutable argument considered harmful'

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -942,3 +942,23 @@ class TestUnusedAssignment(TestCase):
     def test_returnOnly(self):
         """Do not crash on lone "return"."""
         self.flakes('return 2')
+
+    def test_mutableArgList(self):
+        """
+        Test mutable list in function definition.
+        """
+        self.flakes('''
+        def append_one(l=[]):
+            l.append(1)
+            return l
+        ''', m.MutableArg)
+
+    def test_mutableArgDict(self):
+        """
+        Test mutable dict in function definition.
+        """
+        self.flakes('''
+        def set_one(k, d={}):
+            d[k] = 1
+            return d
+        ''', m.MutableArg)


### PR DESCRIPTION
Hi, I wanted to add a test against the problem of the mutable default argument which can cause unexpected behaviour.
- http://docs.python-guide.org/en/latest/writing/gotchas/#mutable-default-arguments
- http://pythonconquerstheuniverse.wordpress.com/2012/02/15/mutable-default-arguments/

Is pyflakes the right place to do so? How can I make it better? Thanks
