### PR TITLE
Add PyPy 5.3 and PyPy3 5.2-alpha1 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ python:
   - 3.5
   - nightly
   - pypy
+  - pypy-5.3
   - pypy3
+  - pypy3.3-5.2-alpha1
 install:
   - pip install flake8==2.1.0 pep8==1.5.6
   - python setup.py install


### PR DESCRIPTION
No changes needed to support these recently released versions.