### PR TITLE
Fix TestMain tests on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,8 @@
+# To activate, change the Appveyor settings to use `.appveyor.yml`.
+install:
+  - python -m pip install tox
+
+build: off
+
+test_script:
+  - python -m tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+skip_missing_interpreters = True
 envlist =
     py26,py27,py32,py33,py34,py35,pypy,pypy3
 


### PR DESCRIPTION
Currently the API test module has failures for TestMain class,
added in f0084592, on Windows as SysStreamCapturing is in
universal newlines mode while its super class IntegrationTests
is using a native console stream with newline=os.linesep.

Add Appveyor CI script as .appveyor.yml,
which can be selected in the Appveyor settings.