### PR TITLE
Fix PyPy2 Windows IntegrationTests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,46 @@
 # To activate, change the Appveyor settings to use `.appveyor.yml`.
 install:
-  - python -m pip install tox
+  - python -m pip install --upgrade virtualenv pip setuptools tox
+
+  # Fetch the three main PyPy releases
+  - ps: (New-Object Net.WebClient).DownloadFile('https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-win32.zip', "$env:appveyor_build_folder\pypy-2.6.1-win32.zip")
+  - ps: 7z x pypy-2.6.1-win32.zip | Out-Null
+  - move pypy-2.6.1-win32 C:\
+
+  - ps: (New-Object Net.WebClient).DownloadFile('https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.1-win32.zip', "$env:appveyor_build_folder\pypy2-v5.3.1-win32.zip")
+  - ps: 7z x pypy2-v5.3.1-win32.zip | Out-Null
+  - move pypy2-v5.3.1-win32 C:\
+
+  - ps: (New-Object Net.WebClient).DownloadFile('https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-win32.zip', "$env:appveyor_build_folder\pypy3-2.4.0-win32.zip")
+  - ps: 7z x pypy3-2.4.0-win32.zip | Out-Null
+  - move pypy3-2.4.0-win32 C:\
+
+  # pypy3 installer provides 'pypy.exe', not pypy3.exe.
+  - copy C:\pypy3-2.4.0-win32\pypy.exe C:\pypy3-2.4.0-win32\pypy3.exe
+
+  # workaround https://github.com/pypa/virtualenv/issues/93
+  - mkdir C:\python33\tcl\tcl8.6
+  - mkdir C:\python33\tcl\tk8.6
+  - mkdir C:\pypy3-2.4.0-win32\tcl\tcl8.6
+  - mkdir C:\pypy3-2.4.0-win32\tcl\tk8.6
+
+  # Only pypy2-5.3.1 is integrated into tox, as pypy3-2.4.0 fails and
+  # a Windows distribution of pypy3-5.2 isnt available yet.
+  - ps: $env:path = "$env:path;C:\pypy2-v5.3.1-win32"
+
+  # pypy3-2.4.0 and pypy-2.6.1 are manually bootstrapped and tested
+  - ps: (New-Object Net.WebClient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', "$env:appveyor_build_folder\get-pip.py")
+  - git clone https://github.com/pypa/setuptools/
+  - cd setuptools
+  - C:\pypy3-2.4.0-win32\pypy3 bootstrap.py
+  - C:\pypy3-2.4.0-win32\pypy3 setup.py install
+  - C:\pypy-2.6.1-win32\pypy bootstrap.py
+  - C:\pypy-2.6.1-win32\pypy setup.py install
+  - cd ..
 
 build: off
 
 test_script:
   - python -m tox
+  - C:\pypy3-2.4.0-win32\pypy3 setup.py test -q
+  - C:\pypy-2.6.1-win32\pypy setup.py test -q


### PR DESCRIPTION
IntegrationTests.test_errors is failing on Windows under PyPy2 as its stderr emits `\r\r\n` as the line separator.

Add AppVeyor testing for three PyPy releases.

Also add a test for the other more complex stderr message emitted by the Reporter.