### PR TITLE
Use %r instead of %s in ImportStarMessage

### DIFF
--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -66,7 +66,7 @@ class ImportStarUsed(Message):
 
 
 class ImportStarUsage(Message):
-    message = "%s may be undefined, or defined from star imports: %s"
+    message = "%r may be undefined, or defined from star imports: %s"
 
     def __init__(self, filename, loc, name, from_list):
         Message.__init__(self, filename, loc)


### PR DESCRIPTION
This was inconsistent with the other error messages. This is useful as
it allows easy detecting of the offending item for editor plugins by
simply searching in the message for quotes.