### PR TITLE
Appveyor: Use setuptools 29

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,8 +30,9 @@ install:
 
   # pypy3-2.4.0 and pypy-2.6.1 are manually bootstrapped and tested
   - ps: (New-Object Net.WebClient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', "$env:appveyor_build_folder\get-pip.py")
-  - git clone https://github.com/pypa/setuptools/
-  - cd setuptools
+  - ps: (New-Object Net.WebClient).DownloadFile('https://github.com/pypa/setuptools/archive/v29.0.1.zip', "$env:appveyor_build_folder\setuptools.zip")
+  - ps: 7z x setuptools.zip | Out-Null
+  - cd setuptools-29.0.1
   - C:\pypy3-2.4.0-win32\pypy3 bootstrap.py
   - C:\pypy3-2.4.0-win32\pypy3 setup.py install
   - C:\pypy-2.6.1-win32\pypy bootstrap.py


### PR DESCRIPTION
setuptools 30 emits an error when run on Python 3.2 based versions.
Install setuptools 29.0.1 to bootstrap the win32 environment
testing pypy-2.6.1 & pypy3-2.4.0.