### PR TITLE
Don't test against file perms when running as root

### DIFF
--- a/pyflakes/test/test_api.py
+++ b/pyflakes/test/test_api.py
@@ -513,6 +513,7 @@ foo = '\\xyz'
             sourcePath, [decoding_error])
 
     @skipIf(sys.platform == 'win32', 'unsupported on Windows')
+    @skipIf(os.getuid() == 0, 'root can do anything')
     def test_permissionDenied(self):
         """
         If the source file is not readable, this is reported on standard

--- a/pyflakes/test/test_api.py
+++ b/pyflakes/test/test_api.py
@@ -513,12 +513,14 @@ foo = '\\xyz'
             sourcePath, [decoding_error])
 
     @skipIf(sys.platform == 'win32', 'unsupported on Windows')
-    @skipIf(os.getuid() == 0, 'root can do anything')
     def test_permissionDenied(self):
         """
         If the source file is not readable, this is reported on standard
         error.
         """
+        if os.getuid() == 0:
+            self.skipTest('root user can access all files regardless of '
+                          'permissions')
         sourcePath = self.makeTempFile('')
         os.chmod(sourcePath, 0)
         count, errors = self.getErrors(sourcePath)


### PR DESCRIPTION
test_permissionDenied tests file modes by creating a temporary file, then sets the mode to 0000 and attempts to process it and see if and permission denied error is generated.  This never happens when the unit tests are run as root since it can open files regardless of file permissions.