### PR TITLE
Pip install setuptools

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,10 +30,10 @@ install:
 
   # pypy3-2.4.0 and pypy-2.6.1 are manually bootstrapped and tested
   - ps: (New-Object Net.WebClient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', "$env:appveyor_build_folder\get-pip.py")
-  - C:\pypy3-2.4.0-win32\pypy3 "$env:appveyor_build_folder\get-pip.py"
-  - C:\pypy3-2.4.0-win32\pypy3 -m pip install -U setuptools
-  - C:\pypy-2.6.1-win32\pypy "$env:appveyor_build_folder\get-pip.py"
-  - C:\pypy-2.6.1-win32\pypy -m pip install -U setuptools
+  - ps: C:\pypy3-2.4.0-win32\pypy3 "$env:appveyor_build_folder\get-pip.py"
+  - ps: C:\pypy3-2.4.0-win32\pypy3 -m pip install -U setuptools
+  - ps: C:\pypy-2.6.1-win32\pypy "$env:appveyor_build_folder\get-pip.py"
+  - ps: C:\pypy-2.6.1-win32\pypy -m pip install -U setuptools
 
 build: off
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,8 @@ install:
 
   # pypy3-2.4.0 and pypy-2.6.1 are manually bootstrapped and tested
   - ps: (New-Object Net.WebClient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', "$env:appveyor_build_folder\get-pip.py")
-  - ps: C:\pypy3-2.4.0-win32\pypy3 "$env:appveyor_build_folder\get-pip.py"
+  # workaround as indicated https://github.com/pypa/pip/issues/2669#issuecomment-136405390
+  - ps: C:\pypy3-2.4.0-win32\pypy3 "$env:appveyor_build_folder\get-pip.py"; C:\pypy3-2.4.0-win32\pypy3 -m pip install -U --force-reinstall pip
   - ps: C:\pypy3-2.4.0-win32\pypy3 -m pip install -U setuptools
   - ps: C:\pypy-2.6.1-win32\pypy "$env:appveyor_build_folder\get-pip.py"
   - ps: C:\pypy-2.6.1-win32\pypy -m pip install -U setuptools

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,13 +30,8 @@ install:
 
   # pypy3-2.4.0 and pypy-2.6.1 are manually bootstrapped and tested
   - ps: (New-Object Net.WebClient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', "$env:appveyor_build_folder\get-pip.py")
-  - git clone https://github.com/pypa/setuptools/
-  - cd setuptools
-  - C:\pypy3-2.4.0-win32\pypy3 bootstrap.py
-  - C:\pypy3-2.4.0-win32\pypy3 setup.py install
-  - C:\pypy-2.6.1-win32\pypy bootstrap.py
-  - C:\pypy-2.6.1-win32\pypy setup.py install
-  - cd ..
+  - C:\pypy3-2.4.0-win32\pypy3 -m pip install -U setuptools
+  - C:\pypy-2.6.1-win32\pypy -m pip install -U setuptools
 
 build: off
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,9 +31,9 @@ install:
   # pypy3-2.4.0 and pypy-2.6.1 are manually bootstrapped and tested
   - ps: (New-Object Net.WebClient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', "$env:appveyor_build_folder\get-pip.py")
   - ps: C:\pypy3-2.4.0-win32\pypy3 "$env:appveyor_build_folder\get-pip.py"; echo bypass
-  - ps: C:\pypy3-2.4.0-win32\pypy3 -m pip install -U setuptools
-  - ps: C:\pypy-2.6.1-win32\pypy "$env:appveyor_build_folder\get-pip.py"
-  - ps: C:\pypy-2.6.1-win32\pypy -m pip install -U setuptools
+  - ps: C:\pypy3-2.4.0-win32\pypy3 -m pip install -U setuptools; echo bypass
+  - ps: C:\pypy-2.6.1-win32\pypy "$env:appveyor_build_folder\get-pip.py"; echo bypass
+  - ps: C:\pypy-2.6.1-win32\pypy -m pip install -U setuptools; echo bypass
 
 build: off
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,8 +31,8 @@ install:
   # pypy3-2.4.0 and pypy-2.6.1 are manually bootstrapped and tested
   - ps: (New-Object Net.WebClient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', "$env:appveyor_build_folder\get-pip.py")
   # errors are ignored due to https://github.com/pypa/pip/issues/2669#issuecomment-136405390
-  - ps: C:\pypy3-2.4.0-win32\pypy3 "$env:appveyor_build_folder\get-pip.py"; echo Ignore the above error
-  - ps: C:\pypy-2.6.1-win32\pypy "$env:appveyor_build_folder\get-pip.py"; echo Ignore the above error
+  - ps: C:\pypy3-2.4.0-win32\pypy3 "$env:appveyor_build_folder\get-pip.py"; C:\pypy3-2.4.0-win32\pypy3 -m pip install -U --force-reinstall pip==8.1.2 setuptools; echo "ignore error"
+  - ps: C:\pypy-2.6.1-win32\pypy "$env:appveyor_build_folder\get-pip.py"
 
 build: off
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,7 +31,7 @@ install:
   # pypy3-2.4.0 and pypy-2.6.1 are manually bootstrapped and tested
   - ps: (New-Object Net.WebClient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', "$env:appveyor_build_folder\get-pip.py")
   # workaround as indicated https://github.com/pypa/pip/issues/2669#issuecomment-136405390
-  - ps: C:\pypy3-2.4.0-win32\pypy3 "$env:appveyor_build_folder\get-pip.py"; C:\pypy3-2.4.0-win32\pypy3 -m pip install -U --force-reinstall pip
+  - ps: C:\pypy3-2.4.0-win32\pypy3 "$env:appveyor_build_folder\get-pip.py"; C:\pypy3-2.4.0-win32\pypy3 -m pip install --force-reinstall pip==8.1.2
   - ps: C:\pypy3-2.4.0-win32\pypy3 -m pip install -U setuptools
   - ps: C:\pypy-2.6.1-win32\pypy "$env:appveyor_build_folder\get-pip.py"
   - ps: C:\pypy-2.6.1-win32\pypy -m pip install -U setuptools

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,7 +31,7 @@ install:
   # pypy3-2.4.0 and pypy-2.6.1 are manually bootstrapped and tested
   - ps: (New-Object Net.WebClient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', "$env:appveyor_build_folder\get-pip.py")
   # errors are ignored due to https://github.com/pypa/pip/issues/2669#issuecomment-136405390
-  - ps: C:\pypy3-2.4.0-win32\pypy3 "$env:appveyor_build_folder\get-pip.py"; C:\pypy3-2.4.0-win32\pypy3 -m pip install -U --force-reinstall pip==8.1.2 setuptools; echo "ignore error"
+  - ps: C:\pypy3-2.4.0-win32\pypy3 "$env:appveyor_build_folder\get-pip.py"; C:\pypy3-2.4.0-win32\pypy3 -m pip install -U --force-reinstall pip==8.1.2 "setuptools<30"; echo "ignore error"
   - ps: C:\pypy-2.6.1-win32\pypy "$env:appveyor_build_folder\get-pip.py"
 
 build: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,8 +30,7 @@ install:
 
   # pypy3-2.4.0 and pypy-2.6.1 are manually bootstrapped and tested
   - ps: (New-Object Net.WebClient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', "$env:appveyor_build_folder\get-pip.py")
-  # workaround as indicated https://github.com/pypa/pip/issues/2669#issuecomment-136405390
-  - ps: C:\pypy3-2.4.0-win32\pypy3 "$env:appveyor_build_folder\get-pip.py"; C:\pypy3-2.4.0-win32\pypy3 -m pip install --force-reinstall pip==8.1.2
+  - ps: C:\pypy3-2.4.0-win32\pypy3 "$env:appveyor_build_folder\get-pip.py"; echo bypass
   - ps: C:\pypy3-2.4.0-win32\pypy3 -m pip install -U setuptools
   - ps: C:\pypy-2.6.1-win32\pypy "$env:appveyor_build_folder\get-pip.py"
   - ps: C:\pypy-2.6.1-win32\pypy -m pip install -U setuptools

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,10 +30,9 @@ install:
 
   # pypy3-2.4.0 and pypy-2.6.1 are manually bootstrapped and tested
   - ps: (New-Object Net.WebClient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', "$env:appveyor_build_folder\get-pip.py")
-  - ps: C:\pypy3-2.4.0-win32\pypy3 "$env:appveyor_build_folder\get-pip.py"; echo bypass
-  - ps: C:\pypy3-2.4.0-win32\pypy3 -m pip install -U setuptools; echo bypass
-  - ps: C:\pypy-2.6.1-win32\pypy "$env:appveyor_build_folder\get-pip.py"; echo bypass
-  - ps: C:\pypy-2.6.1-win32\pypy -m pip install -U setuptools; echo bypass
+  # errors are ignored due to https://github.com/pypa/pip/issues/2669#issuecomment-136405390
+  - ps: C:\pypy3-2.4.0-win32\pypy3 "$env:appveyor_build_folder\get-pip.py"; echo Ignore the above error
+  - ps: C:\pypy-2.6.1-win32\pypy "$env:appveyor_build_folder\get-pip.py"; echo Ignore the above error
 
 build: off
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,9 @@ install:
 
   # pypy3-2.4.0 and pypy-2.6.1 are manually bootstrapped and tested
   - ps: (New-Object Net.WebClient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', "$env:appveyor_build_folder\get-pip.py")
+  - C:\pypy3-2.4.0-win32\pypy3 "$env:appveyor_build_folder\get-pip.py"
   - C:\pypy3-2.4.0-win32\pypy3 -m pip install -U setuptools
+  - C:\pypy-2.6.1-win32\pypy "$env:appveyor_build_folder\get-pip.py"
   - C:\pypy-2.6.1-win32\pypy -m pip install -U setuptools
 
 build: off


### PR DESCRIPTION
These changes work around pypa/pip#2669 enabling pip to be installed into pypy and avoid using a manual install of setuptools, deprecated in pypa/setuptools#581.