### PR TITLE
Process function scope variable annotations

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -1337,19 +1337,12 @@ class Checker(object):
                 pass
 
     def ANNASSIGN(self, node):
-        """
-        Annotated assignments don't have annotations evaluated on function
-        scope, hence the custom implementation.
-
-        See: PEP 526.
-        """
         if node.value:
             # Only bind the *targets* if the assignment has a value.
             # Otherwise it's not really ast.Store and shouldn't silence
             # UndefinedLocal warnings.
             self.handleNode(node.target, node)
-        if not isinstance(self.scope, FunctionScope):
-            self.handleNode(node.annotation, node)
+        self.handleNode(node.annotation, node)
         if node.value:
             # If the assignment has value, handle the *value* now.
             self.handleNode(node.value, node)

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -1839,12 +1839,17 @@ class TestAsyncStatements(TestCase):
             name: str = 'Bob'
             age: int = 18
             foo: not_a_real_type = None
-        ''', m.UnusedVariable, m.UnusedVariable, m.UnusedVariable)
+        ''', m.UnusedVariable, m.UnusedVariable, m.UnusedVariable, m.UndefinedName)
         self.flakes('''
         def f():
             name: str
             print(name)
         ''', m.UndefinedName)
+        self.flakes('''
+        from typing import Any
+        def f():
+            a: Any
+        ''')
         self.flakes('''
         foo: not_a_real_type
         ''', m.UndefinedName)


### PR DESCRIPTION
Even though variable annotations in function scope aren't evaluated at
runtime it's still useful for static analysis tools to process them and
catch some issues (and not report some things that aren't issues).

Let's take the following code:

```python
     from typing import Any

     def fun():
          a: Any
```

Previously pyflakes would report Any to be unused:

```
     test.py:1: 'typing.Any' imported but unused
```

With this patch it's no longer the case.