### PR TITLE
Remove obsolete version of Python from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 python:
   - 2.6
   - 2.7
-  - 3.2
   - 3.3
   - 3.4
   - 3.5
+  - 3.6
   - nightly
   - pypy
   - pypy-5.3


### PR DESCRIPTION
This also adds the latest version of Python.

The `setuptools` on Travis CI no longer supports Python 3.2:

https://github.com/pypa/setuptools/commit/b47fe15b9039a165589353a1a43f6dfe3bbe3a8e
https://travis-ci.org/myint/scspell/jobs/235721220#L146