### PR TITLE
Use new URL for issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Share your feedback and ideas: `subscribe to the mailing-list
 Contributing
 ------------
 
-Issues are tracked on `Launchpad <https://bugs.launchpad.net/pyflakes>`_.
+Issues are tracked on `GitHub <https://github.com/PyCQA/pyflakes/issues>`_.
 
 Patches may be submitted via a `GitHub pull request`_ or via the mailing list
 if you prefer. If you are comfortable doing so, please `rebase your changes`_


### PR DESCRIPTION
- [x] Also, could someone with admin access update the banner? I'm not sure what it should point to now. I often point it to PyPI.
- [x] I also noticed that `pyflakes` is one of the only repository in `PyCQA` that ends its description with a period. It might be good to remove it for uniformity.
![screen shot 2017-05-28 at 07 17 26](https://cloud.githubusercontent.com/assets/1235108/26529524/279e94b2-4376-11e7-9f4d-6c986f38c637.png)
- [ ] We probably want to point the description in [the old Launchpad site](https://launchpad.net/pyflakes) to GitHub. I don't have access to do this.
![screen shot 2017-05-28 at 07 27 04](https://cloud.githubusercontent.com/assets/1235108/26529582/26342bf4-4377-11e7-9def-8091041e2803.png)

Thanks!