### PR TITLE
Find Python files without extensions

### DIFF
--- a/pyflakes/api.py
+++ b/pyflakes/api.py
@@ -5,12 +5,16 @@ from __future__ import with_statement
 
 import sys
 import os
+import re
 import _ast
 
 from pyflakes import checker, __version__
 from pyflakes import reporter as modReporter
 
 __all__ = ['check', 'checkPath', 'checkRecursive', 'iterSourceCode', 'main']
+
+
+PYTHON_SHEBANG_REGEX = re.compile(br'^#!.*\bpython[23]?\b\s*$')
 
 
 def check(codeString, filename, reporter=None):
@@ -108,6 +112,25 @@ def checkPath(filename, reporter=None):
     return check(codestr, filename, reporter)
 
 
+def isPythonFile(filename):
+    """Return True if filename points to a Python file."""
+    if filename.endswith('.py'):
+        return True
+
+    max_bytes = 128
+
+    try:
+        with open(filename, 'rb') as f:
+            text = f.read(max_bytes)
+            if not text:
+                return False
+    except IOError:
+        return False
+
+    first_line = text.splitlines()[0]
+    return PYTHON_SHEBANG_REGEX.match(first_line)
+
+
 def iterSourceCode(paths):
     """
     Iterate over all Python source files in C{paths}.
@@ -120,8 +143,9 @@ def iterSourceCode(paths):
         if os.path.isdir(path):
             for dirpath, dirnames, filenames in os.walk(path):
                 for filename in filenames:
-                    if filename.endswith('.py'):
-                        yield os.path.join(dirpath, filename)
+                    full_path = os.path.join(dirpath, filename)
+                    if isPythonFile(full_path):
+                        yield full_path
         else:
             yield path
 

--- a/pyflakes/test/test_api.py
+++ b/pyflakes/test/test_api.py
@@ -187,6 +187,22 @@ class TestIterSourceCode(TestCase):
             sorted(iterSourceCode([self.tempdir])),
             sorted([apath, bpath, cpath]))
 
+    def test_shebang(self):
+        """
+        Find Python files that don't end with `.py`, but contain a Python
+        shebang.
+        """
+        apath = os.path.join(self.tempdir, 'a')
+        fd = open(apath, 'w')
+        fd.write('#!/usr/bin/env python\n')
+        fd.close()
+
+        self.makeEmptyFile('b')
+
+        self.assertEqual(
+            list(iterSourceCode([self.tempdir])),
+            list([apath]))
+
     def test_multipleDirectories(self):
         """
         L{iterSourceCode} can be given multiple directories.  It will recurse


### PR DESCRIPTION
Previously, only files ending in `.py` would be detected as Python files while recursing a directory. This   pull request allows for detecting Python files by also looking for shebangs. I'm using the same technique that I've used in `autopep8` for years.

I timed this against the ~7000 files in `/opt/local/Library/Frameworks/Python.framework/Versions/3.6/`.

Three timings before this change:

```
0m23.091s
0m22.792s
0m22.745s
```

Three timings after this change:

```
0m23.046s
0m23.111s
0m22.860s
```

This closes #149.