### PR TITLE
Match tested Python versions in tox and Travis configurations

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skip_missing_interpreters = True
 envlist =
-    py26,py27,py32,py33,py34,py35,pypy,pypy3
+    py26,py27,py33,py34,py35,py36,pypy,pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
Match tox test matrix with and Travis configurations.
    
Testing for Python 3.2 was removed in c94e50759839b781cdbb029ae68f8069234ada3b.
