### PR TITLE
Make `pyflakes` happy about its our own code

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -42,6 +42,9 @@ else:
     def getNodeType(node_class):
         return node_class.__name__.upper()
 
+    # Silence `pyflakes` from reporting `undefined name 'unicode'` in Python 3.
+    unicode = str
+
 # Python >= 3.3 uses ast.Try instead of (ast.TryExcept + ast.TryFinally)
 if PY32:
     def getAlternatives(n):


### PR DESCRIPTION
From https://github.com/PyCQA/pyflakes/issues/246#issuecomment-330001086:

> It does seem unfortunate that `pyflakes` doesn't run cleanly on its own codebase. I run into this every time I edit `pyflakes/checker.py`.
>
> ```
> $ pyflakes .
> ./pyflakes/checker.py:40: undefined name 'unicode'
> ```

*Note that Travis CI's `pypy3` will fail for an unrelated reason. Fixing that requires merging #294.*