### PR TITLE
Test PEP 553 `breakpoint()`

### DIFF
--- a/pyflakes/test/test_undefined_names.py
+++ b/pyflakes/test/test_undefined_names.py
@@ -218,6 +218,10 @@ class Test(TestCase):
         """
         self.flakes('WindowsError')
 
+    @skipIf(version_info < (3, 7), 'breakpoint is a new builtin in Python 3.7')
+    def test_builtinBreakpoint(self):
+        self.flakes('breakpoint()')
+
     def test_magicGlobalsFile(self):
         """
         Use of the C{__file__} magic global should not emit an undefined name


### PR DESCRIPTION
This closes #300.