### PR TITLE
Update versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ parsing the source file, not importing it, so it is safe to use on
 modules with side effects.  It's also much faster.
 
 It is `available on PyPI <https://pypi.python.org/pypi/pyflakes>`_
-and it supports all active versions of Python: 2.7 and 3.4 to 3.6.
+and it supports all active versions of Python: 2.7 and 3.4 to 3.7.
 
 
 
@@ -32,7 +32,7 @@ Useful tips:
 
 * If you require more options and more flexibility, you could give a
   look to Flake8_ too.
-  
+
 
 Design Principles
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development",


### PR DESCRIPTION
Python 3.7 is supported (#271, #273), so include it in README.

And update the classifiers to reflect the officially supported versions.
* ~I take it Python 2.5 is still officially supported, but not testable on Travis.~
  * ~Let me know if this is no longer the case!~
* ~I've left out 3.0, 3.1 and 3.2 as unsupported, as 3.2 is testable on Travis but isn't.~
  * ~Let me know if that should be adjusted!~

Edit: now https://github.com/PyCQA/pyflakes/pull/322 is merged, this just adds Python 3.7.