### PR TITLE
 Fix failed AppVeyor web requests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,7 @@
 # To activate, change the Appveyor settings to use `.appveyor.yml`.
 install:
+  - ps: "[Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
+
   - python -m pip install --upgrade virtualenv pip setuptools tox
 
   # Fetch the three main PyPy releases


### PR DESCRIPTION
<s>It is marking all contributions as broken which is not helpful for reviewing.</s>

---

<s>Someone will need to sign into AppVeyor to disable it there.</s>

---

Allow we requests to servers that only support TLS 1.2. Previously failed with the error:

```
Exception calling "DownloadFile" with "2" argument(s): "The request was aborted: Could not create SSL/TLS secure channel."
```

Was marking all contributions as broken which is not helpful for reviewing.

Fixes #308