### PR TITLE
Make unused for loop variables to be reported

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -356,6 +356,12 @@ class Assignment(Binding):
     """
 
 
+class FOR_LOOP_VARIABLE(Binding):
+    """
+    Represents binding a name as a loop variable
+    """
+
+
 class FunctionDefinition(Definition):
     pass
 
@@ -412,6 +418,7 @@ class FunctionScope(Scope):
     usesLocals = False
     alwaysUsed = set(['__tracebackhide__',
                       '__traceback_info__', '__traceback_supplement__'])
+    namesToIgnore = ('_', '_unused')
 
     def __init__(self):
         super(FunctionScope, self).__init__()
@@ -425,9 +432,12 @@ class FunctionScope(Scope):
         Return a generator for the assignments which have not been used.
         """
         for name, binding in self.items():
-            if (not binding.used and name not in self.globals
-                    and not self.usesLocals
-                    and isinstance(binding, Assignment)):
+            if (not binding.used and name not in self.globals and
+                    not self.usesLocals and
+                    isinstance(binding, (Assignment, FOR_LOOP_VARIABLE))):
+
+                if isinstance(binding, FOR_LOOP_VARIABLE) and name in self.namesToIgnore:
+                    continue
                 yield name, binding
 
 
@@ -774,12 +784,14 @@ class Checker(object):
                     break
 
         parent_stmt = self.getParent(node)
-        if isinstance(parent_stmt, (ast.For, ast.comprehension)) or (
+        if isinstance(parent_stmt, (ast.comprehension, )) or (
                 parent_stmt != node.parent and
                 not self.isLiteralTupleUnpacking(parent_stmt)):
             binding = Binding(name, node)
         elif name == '__all__' and isinstance(self.scope, ModuleScope):
             binding = ExportBinding(name, node.parent, self.scope)
+        elif isinstance(parent_stmt, ast.For):
+            binding = FOR_LOOP_VARIABLE(name, node)
         else:
             binding = Assignment(name, node)
         self.addBinding(node, binding)

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -1159,6 +1159,16 @@ class TestUnusedAssignment(TestCase):
             b = 1
         ''', m.UnusedVariable)
 
+    def test_unusedVariableUnderscore(self):
+        """
+        Warn when a variable in a function is assigned a value that's never
+        used.
+        """
+        self.flakes('''
+        def a():
+            _ = 1
+        ''', m.UnusedVariable)
+
     def test_unusedVariableAsLocals(self):
         """
         Using locals() it is perfectly valid to have unused variables
@@ -1247,11 +1257,24 @@ class TestUnusedAssignment(TestCase):
 
     def test_assignInForLoop(self):
         """
-        Don't warn when a variable in a for loop is assigned to but not used.
+        Warn when a variable in a for loop is assigned to but not used.
         """
         self.flakes('''
         def f():
             for i in range(10):
+                pass
+        ''', m.UnusedVariable)
+
+    def test_assignInForLoopWithIgnoredName(self):
+        """
+        Don't warn when a variable named '_' or '_unused' in a for loop
+        is assigned to but not used.
+        """
+        self.flakes('''
+        def f():
+            for _ in range(10):
+                pass
+            for _unused in range(10):
                 pass
         ''')
 


### PR DESCRIPTION
Unused for loop variables are curently not reported by pyflakes. There may be valid reasons why a loop variable is not used.  Nevertheless there should be a warning unless the developer names the variable '_' or 'unused' which is a widely used convention for this case, 

My commit passes all tests and adds a few ones for the new behaviour.

