### PR TITLE
Work around Travis CI error on Python "nightly"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ python:
   - pypy3.3-5.2-alpha1
 install:
   - pip install flake8==2.1.0 pep8==1.5.6
-  - python setup.py install
+  - pip install .
   - pip list
   - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then flake8 --version; fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,10 @@ python:
   - pypy3
   - pypy3.3-5.2-alpha1
 install:
-  - pip install flake8==2.1.0 pep8==1.5.6
-  - pip install .
+  - pip install --upgrade .
   - pip list
   - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then flake8 --version; fi
 script:
   - python setup.py test -q
-  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then flake8 pyflakes setup.py; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then pip install flake8==2.1.0 pep8==1.5.6 && flake8 pyflakes setup.py; fi
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ python:
 install:
   - pip install --upgrade .
   - pip list
-  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then flake8 --version; fi
 script:
   - python setup.py test -q
-  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then pip install flake8==2.1.0 pep8==1.5.6 && flake8 pyflakes setup.py; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then pip install flake8==2.1.0 pep8==1.5.6 && flake8 --version && flake8 pyflakes setup.py; fi
 sudo: false


### PR DESCRIPTION
It looks like Python "nightly" (3.7) is generating bytecode that is unrecognized by `marshal.load()`. I previously dealt with this Travis error in `autoflake` using this same approach.

Before this workaround:

https://travis-ci.org/PyCQA/pyflakes/jobs/334251140
```
$ python setup.py install
...
  File "setup.py", line 58, in <module>
    **extra)
  File "/home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages/setuptools/__init__.py", line 129, in setup
    return distutils.core.setup(**attrs)
  File "/opt/python/3.7-dev/lib/python3.7/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/opt/python/3.7-dev/lib/python3.7/distutils/dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "/opt/python/3.7-dev/lib/python3.7/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages/setuptools/command/install.py", line 67, in run
    self.do_egg_install()
  File "/home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages/setuptools/command/install.py", line 109, in do_egg_install
    self.run_command('bdist_egg')
  File "/opt/python/3.7-dev/lib/python3.7/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "/opt/python/3.7-dev/lib/python3.7/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages/setuptools/command/bdist_egg.py", line 218, in run
    os.path.join(archive_root, 'EGG-INFO'), self.zip_safe()
  File "/home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages/setuptools/command/bdist_egg.py", line 269, in zip_safe
    return analyze_egg(self.bdist_dir, self.stubs)
  File "/home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages/setuptools/command/bdist_egg.py", line 379, in analyze_egg
    safe = scan_module(egg_dir, base, name, stubs) and safe
  File "/home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages/setuptools/command/bdist_egg.py", line 416, in scan_module
    code = marshal.load(f)
ValueError: bad marshal data (unknown type code)
```

After this workaround:

https://travis-ci.org/PyCQA/pyflakes/jobs/334251862
```
$ pip install .
Processing /home/travis/build/PyCQA/pyflakes
  Requirement already satisfied (use --upgrade to upgrade): pyflakes==1.6.0 from file:///home/travis/build/PyCQA/pyflakes in /home/travis/virtualenv/python3.7-dev/lib/python3.7/site-packages
```