### PR TITLE
ENH: Warn on raise NotImplemented(...).

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -965,7 +965,7 @@ class Checker(object):
 
     # "stmt" type nodes
     DELETE = PRINT = FOR = ASYNCFOR = WHILE = IF = WITH = WITHITEM = \
-        ASYNCWITH = ASYNCWITHITEM = RAISE = TRYFINALLY = EXEC = \
+        ASYNCWITH = ASYNCWITHITEM = TRYFINALLY = EXEC = \
         EXPR = ASSIGN = handleChildren
 
     PASS = ignore
@@ -988,6 +988,22 @@ class Checker(object):
         BITOR = BITXOR = BITAND = FLOORDIV = INVERT = NOT = UADD = USUB = \
         EQ = NOTEQ = LT = LTE = GT = GTE = IS = ISNOT = IN = NOTIN = \
         MATMULT = ignore
+
+    def RAISE(self, node):
+        self.handleChildren(node)
+
+        # Check for `
+        raise_arg = node.exc
+        if not isinstance(raise_arg, ast.Call):
+            return
+
+        func = raise_arg.func
+        if not isinstance(func, ast.Name):
+            return
+
+        name = getNodeName(func)
+        if name == 'NotImplemented':
+            self.report(messages.RaiseNotImplemented, node)
 
     # additional node types
     COMPREHENSION = KEYWORD = FORMATTEDVALUE = JOINEDSTR = handleChildren

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -239,3 +239,7 @@ class ForwardAnnotationSyntaxError(Message):
     def __init__(self, filename, loc, annotation):
         Message.__init__(self, filename, loc)
         self.message_args = (annotation,)
+
+
+class RaiseNotImplemented(Message):
+    message = "'raise NotImplemented(...)' should be 'raise NotImplementedError(...)'"

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -1983,3 +1983,12 @@ class TestAsyncStatements(TestCase):
         self.flakes('''
         a: 'a: "A"'
         ''', m.ForwardAnnotationSyntaxError)
+
+    def test_raise_notimplemented(self):
+        self.flakes('''
+        raise NotImplementedError("This is fine")
+        ''')
+
+        self.flakes('''
+        raise NotImplemented("This isn't gonna work")
+        ''', m.RaiseNotImplemented)


### PR DESCRIPTION
This is a common mistake for `raise NotImplementedError`. Since
`NotImplemented` isn't an exception, it's never valid to raise
it (barring strange circumstances where you've aliased `NotImplemented`
in `__builtins__`).