### PR TITLE
checker.py: Check for invalid print syntax

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -768,6 +768,13 @@ class Checker(object):
                     # iteration
                     continue
 
+            if (name == 'print' and
+                    isinstance(scope.get(name, None), Builtin)):
+                parent = self.getParent(node)
+                if (isinstance(parent, ast.BinOp) and
+                        isinstance(parent.op, ast.RShift)):
+                    self.report(messages.InvalidPrintSyntax, node)
+
             try:
                 scope[name].used = (self.scope, node)
             except KeyError:

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -250,3 +250,7 @@ class ForwardAnnotationSyntaxError(Message):
 
 class RaiseNotImplemented(Message):
     message = "'raise NotImplemented' should be 'raise NotImplementedError'"
+
+
+class InvalidPrintSyntax(Message):
+    message = 'use of >> is invalid with print function'


### PR DESCRIPTION
New warning added in messages.py to check for invalid
python syntax

Closes https://github.com/PyCQA/pyflakes/issues/242