### PR TITLE
WIP: Parse type annotations

### DIFF
--- a/pyflakes/api.py
+++ b/pyflakes/api.py
@@ -38,7 +38,7 @@ def check(codeString, filename, reporter=None):
         reporter = modReporter._makeDefaultReporter()
     # First, compile into an AST and handle syntax errors.
     try:
-        tree = compile(codeString, filename, "exec", _ast.PyCF_ONLY_AST)
+        tree = checker.ast_compile(codeString, filename)
     except SyntaxError:
         value = sys.exc_info()[1]
         msg = value.args[0]

--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -72,6 +72,11 @@ else:
     LOOP_TYPES = (ast.While, ast.For, ast.AsyncFor)
 
 
+def ast_compile(codeString, filename):
+    tree = compile(codeString, filename, 'exec', ast.PyCF_ONLY_AST)
+    return tree
+
+
 class _FieldsOrder(dict):
     """Fix order of AST node fields."""
 
@@ -920,7 +925,7 @@ class Checker(object):
             self.builtIns.add('_')
         for example in examples:
             try:
-                tree = compile(example.source, "<doctest>", "exec", ast.PyCF_ONLY_AST)
+                tree = ast_compile(example.source, "<doctest>")
             except SyntaxError:
                 e = sys.exc_info()[1]
                 if PYPY:

--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -22,14 +22,19 @@ except AttributeError:
 builtin_vars = dir(__import__('__builtin__' if PY2 else 'builtins'))
 
 try:
-    import ast
-except ImportError:     # Python 2.5
-    import _ast as ast
+    from typed_ast import ast3 as ast
+    _compile = ast.parse
+except ImportError:
+    try:
+        import ast
+    except ImportError:     # Python 2.5
+        import _ast as ast
 
-    if 'decorator_list' not in ast.ClassDef._fields:
-        # Patch the missing attribute 'decorator_list'
-        ast.ClassDef.decorator_list = ()
-        ast.FunctionDef.decorator_list = property(lambda s: s.decorators)
+        if 'decorator_list' not in ast.ClassDef._fields:
+            # Patch the missing attribute 'decorator_list'
+            ast.ClassDef.decorator_list = ()
+            ast.FunctionDef.decorator_list = property(lambda s: s.decorators)
+    _compile = compile
 
 from pyflakes import messages
 
@@ -73,7 +78,7 @@ else:
 
 
 def ast_compile(codeString, filename):
-    tree = compile(codeString, filename, 'exec', ast.PyCF_ONLY_AST)
+    tree = _compile(codeString, filename, 'exec', ast.PyCF_ONLY_AST)
     return tree
 
 

--- a/pyflakes/test/harness.py
+++ b/pyflakes/test/harness.py
@@ -21,7 +21,7 @@ class TestCase(unittest.TestCase):
     withDoctest = False
 
     def flakes(self, input, *expectedOutputs, **kw):
-        tree = compile(textwrap.dedent(input), "<test>", "exec", PyCF_ONLY_AST)
+        tree = checker.ast_compile(textwrap.dedent(input), "<test>")
         w = checker.Checker(tree, withDoctest=self.withDoctest, **kw)
         outputs = [type(o) for o in w.messages]
         expectedOutputs = list(expectedOutputs)

--- a/pyflakes/test/test_imports.py
+++ b/pyflakes/test/test_imports.py
@@ -147,6 +147,40 @@ class Test(TestCase):
         self.flakes('from .. import fu; assert fu')
         self.flakes('from ..bar import fu as baz; assert baz')
 
+    def test_usedImportFunctionTypeComment(self):
+        self.flakes('''
+        from foo import Foo
+        def takes_foo(foo):
+            # type: (Foo) -> None
+            pass
+        ''')
+        self.flakes('''
+        from foo import Foo
+        def returns_foo(foo):
+            # type: () -> Foo
+            pass
+        ''')
+        self.flakes('''
+        from foo import Foo, Bar, Baz
+        def takes_and_returns_foo(foo, bar):
+            # type: (Foo, Bar) -> Baz
+            pass
+        ''')
+
+    def test_usedImportVariableTypeComment(self):
+        self.flakes('''from foo import Foo; foo = None # type: Foo''')
+        # TODO: multiple variables (a, b) = [], []  # type: a, b
+        # TODO: multiple variables (a, b) = [], []  # type: (a, b)
+
+    def test_usedImportForTypeComment(self):
+        # TODO: for x in xs:  # type: x
+        # TODO: for x, y in xs:  # type: x, y
+        pass
+
+    def test_usedImportWithTypeComment(self):
+        # TODO: with x as y:  # type: y
+        pass
+
     def test_redefinedWhileUnused(self):
         self.flakes('import fu; fu = 3', m.RedefinedWhileUnused)
         self.flakes('import fu; fu, bar = 3', m.RedefinedWhileUnused)


### PR DESCRIPTION
Here is a proof of concept of parsing type annotations.

It adds a dependency which is implicit and needs Python 3.x to work, since typed_ast does not work on Python 2.7 (not properly checked).

If you think this is worthwhile I can spend some more time fixing it up so that it checks for the right modules and python versions.

This should fix issue 247.