### PR TITLE
skip Emacs/vim backup files

### DIFF
--- a/pyflakes/api.py
+++ b/pyflakes/api.py
@@ -117,6 +117,10 @@ def isPythonFile(filename):
     if filename.endswith('.py'):
         return True
 
+    # Avoid obvious backup files (Emacs & vim)
+    if filename.endswith("~"):
+        return False
+
     max_bytes = 128
 
     try:

--- a/pyflakes/api.py
+++ b/pyflakes/api.py
@@ -117,7 +117,7 @@ def isPythonFile(filename):
     if filename.endswith('.py'):
         return True
 
-    # Avoid obvious backup files (Emacs & vim)
+    # Avoid obvious Emacs backup files
     if filename.endswith("~"):
         return False
 

--- a/pyflakes/test/test_api.py
+++ b/pyflakes/test/test_api.py
@@ -180,6 +180,7 @@ class TestIterSourceCode(TestCase):
         """
         os.mkdir(os.path.join(self.tempdir, 'foo'))
         apath = self.makeEmptyFile('foo', 'a.py')
+        self.makeEmptyFile('foo', 'a.py~')
         os.mkdir(os.path.join(self.tempdir, 'bar'))
         bpath = self.makeEmptyFile('bar', 'b.py')
         cpath = self.makeEmptyFile('c.py')


### PR DESCRIPTION
isPythonFile should ignore obvious editor backup files. This pull request handles Emacs and vim products.