### PR TITLE
regression in 2.0.0: add test for false warning about unused exception when using locals()

### DIFF
--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -1650,6 +1650,15 @@ class TestUnusedAssignment(TestCase):
             except (tokenize.TokenError, IndentationError): pass
         ''')
 
+    def test_exceptUnusedAsLocals(self):
+        """
+        Don't issue false warning when an exception is used by locals().
+        """
+        self.flakes('''
+        try: raise ValueError()
+        except ValueError as e: locals()
+        ''')
+
     def test_augmentedAssignmentImportedFunctionCall(self):
         """
         Consider a function that is called on the right part of an


### PR DESCRIPTION
This patch adds a test for a case which worked with the previous release (1.6.0, no warning) but fails with the latest release (2.0.0, false warning about unused `e`).

Since I don't know where / when between the releases the behavior regressed I created this test to cover that use case. Once the bug has been fixed the test should pass again.