### PR TITLE
Fix broken PyPy installation in AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,7 +31,7 @@ install:
 
   # Only pypy2-5.3.1 is integrated into tox, as pypy3-2.4.0 fails and
   # a Windows distribution of pypy3-5.2 isnt available yet.
-  - ps: $env:path = "$env:path;C:\pypy2-v5.3.1-win32"
+  - ps: $env:path = "$env:path;C:\pypy2-v5.3.1-win32;C:\pypy-2.6.1-win32\bin"
 
   # pypy3-2.4.0 and pypy-2.6.1 are manually bootstrapped and tested
   - ps: (New-Object Net.WebClient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', "$env:appveyor_build_folder\get-pip.py")


### PR DESCRIPTION
Currently, every pull requests fails because of [this](https://ci.appveyor.com/project/sigmavirus24/pyflakes/build/1.0.182).

```
48Installing collected packages: pip, setuptools, wheel
49C:\pypy-2.6.1-win32\pypy :   The script wheel.exe is installed in 'C:\pypy-2.6.1-win32\bin' which is not on PATH.
50At line:1 char:1
51+ C:\pypy-2.6.1-win32\pypy "$env:appveyor_build_folder\get-pip.py"
52+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
53    + CategoryInfo          : NotSpecified: (  The script wh...is not on PATH.:String) [], RemoteException
54    + FullyQualifiedErrorId : NativeCommandError
55 
56
57  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
58
59Successfully installed pip-10.0.1 setuptools-39.2.0 wheel-0.31.1
60Command executed with exception: 
61  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
62
```