### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Pyflakes analyzes programs and detects various errors.  It works by
 parsing the source file, not importing it, so it is safe to use on
 modules with side effects.  It's also much faster.
 
-It is `available on PyPI <https://pypi.python.org/pypi/pyflakes>`_
+It is `available on PyPI <https://pypi.org/project/pyflakes/>`_
 and it supports all active versions of Python: 2.7 and 3.4 to 3.7.
 
 
@@ -77,7 +77,7 @@ All changes should include tests and pass flake8_.
    :alt: Build status
 
 .. _Pylint: http://www.pylint.org/
-.. _flake8: https://pypi.python.org/pypi/flake8
+.. _flake8: https://pypi.org/project/flake8/
 .. _`PEP 8`: http://legacy.python.org/dev/peps/pep-0008/
 .. _Pychecker: http://pychecker.sourceforge.net/
 .. _`rebase your changes`: https://git-scm.com/book/en/v2/Git-Branching-Rebasing


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html