### PR TITLE
checker.py: Handle UnboundLocal error for builtins

### DIFF
--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -100,12 +100,19 @@ class UndefinedExport(Message):
 
 
 class UndefinedLocal(Message):
-    message = ('local variable %r (defined in enclosing scope on line %r) '
-               'referenced before assignment')
+    message = 'local variable %r {0} referenced before assignment'
+
+    default = 'defined in enclosing scope on line %r'
+    builtin = 'defined as a builtin'
 
     def __init__(self, filename, loc, name, orig_loc):
         Message.__init__(self, filename, loc)
-        self.message_args = (name, orig_loc.lineno)
+        if orig_loc is None:
+            self.message = self.message.format(self.builtin)
+            self.message_args = name
+        else:
+            self.message = self.message.format(self.default)
+            self.message_args = (name, orig_loc.lineno)
 
 
 class DuplicateArgument(Message):

--- a/pyflakes/test/test_builtin.py
+++ b/pyflakes/test/test_builtin.py
@@ -1,0 +1,41 @@
+"""
+Tests for detecting redefinition of builtins.
+"""
+from sys import version_info
+
+from pyflakes import messages as m
+from pyflakes.test.harness import TestCase, skipIf
+
+
+class TestBuiltins(TestCase):
+
+    def test_builtin_unbound_local(self):
+        self.flakes('''
+        def foo():
+            a = range(1, 10)
+            range = a
+            return range
+
+        foo()
+
+        print(range)
+        ''', m.UndefinedLocal)
+
+    def test_global_shadowing_builtin(self):
+        self.flakes('''
+        def f():
+            global range
+            range = None
+            print(range)
+
+        f()
+        ''')
+
+    @skipIf(version_info >= (3,), 'not an UnboundLocalError in Python 3')
+    def test_builtin_in_comprehension(self):
+        self.flakes('''
+        def f():
+            [range for range in range(1, 10)]
+
+        f()
+        ''', m.UndefinedLocal)


### PR DESCRIPTION
This patch ensures that UnboundLocalError is not
ignored for Python builtins. Populates ModuleScope
with Builtin nodes to manage them as bindings.

Fixes https://github.com/PyCQA/pyflakes/issues/350