### PR TITLE
test_errors_syntax: Expect SystemExit error code 1

### DIFF
--- a/pyflakes/test/test_api.py
+++ b/pyflakes/test/test_api.py
@@ -757,7 +757,7 @@ class IntegrationTests(TestCase):
         d = self.runPyflakes([self.tempfilepath])
         error_msg = '{0}:1:{2}: invalid syntax{1}import{1}    {3}^{1}'.format(
             self.tempfilepath, os.linesep, 5 if PYPY else 7, '' if PYPY else '  ')
-        self.assertEqual(d, ('', error_msg, True))
+        self.assertEqual(d, ('', error_msg, 1))
 
     def test_readFromStdin(self):
         """
@@ -778,6 +778,8 @@ class TestMain(IntegrationTests):
             with SysStreamCapturing(stdin) as capture:
                 main(args=paths)
         except SystemExit as e:
-            return (capture.output, capture.error, e.code)
+            self.assertIsInstance(e.code, bool)
+            rv = int(e.code)
+            return (capture.output, capture.error, rv)
         else:
             raise RuntimeError('SystemExit not raised')


### PR DESCRIPTION
The test was written to expect SystemExit error code of True.
The SystemExit raised by api.main is of type bool.

True and 1 are equal, and assertEqual treats them that way,
so there is no difference between them.

The other tests in this class expect an int error code,
due to the use of Popen which will convert the SystemExit
bool to an int.  Hence this patch switches to using 1.

More importantly, TestMain.runPyflakes is updated to check
the api.main error code is a bool, and then force the
conversion to int, so that any errors from self.assertEqual
do not show differences of 1 vs True, when in fact assertEqual
considers them to be identical.  These differences of 1 vs True
are distracting to whatever other differences are presented,
especially in error offset bugs like regularly occur, such as
https://github.com/PyCQA/pyflakes/issues/346.