### PR TITLE
Detect broken string interpolation and formatting

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -141,7 +141,7 @@ def convert_to_value(item):
         return UnhandledKeyType()
 
 
-class DummyInterpolationArg(object):
+class DummyInterpolationArg(int):
     """
     Dummy arguments used for string interpolation
     """

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -254,3 +254,11 @@ class RaiseNotImplemented(Message):
 
 class InvalidPrintSyntax(Message):
     message = 'use of >> is invalid with print function'
+
+
+class InvalidStringInterpolation(Message):
+    message = 'invalid string interpolation: %s'
+
+    def __init__(self, filename, loc, message):
+        Message.__init__(self, filename, loc)
+        self.message_args = (message,)

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -262,3 +262,20 @@ class InvalidStringInterpolation(Message):
     def __init__(self, filename, loc, message):
         Message.__init__(self, filename, loc)
         self.message_args = (message,)
+
+
+class InvalidStringFormatSpecification(Message):
+    message = 'invalid string format specification'
+
+
+class StringFormatTupleOutOfRange(Message):
+    message = 'tuple index out of range in string format specification'
+
+
+class StringFormatKeyError(Message):
+    message = 'key error in string format specification'
+
+
+class StringFormatMixFieldSpecification(Message):
+    message = 'cannot switch from automatic field numbering ' \
+              'to manual field specification'

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -2095,6 +2095,7 @@ class TestStringInterpolation(TestCase):
         "%d %i %o %u %x %X %e   %E   %f   %F   %g   %G  %c  %r     %s" % \
         (1, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1, "foo", "bar")
         ''')
+        self.flakes('"%*f" % (1, 1.0)')
         self.flakes('"%s" % "foo"')
         self.flakes('r"%s" % b"foo"')
         self.flakes('u"%s" % r"foo"')
@@ -2138,7 +2139,8 @@ class TestStringInterpolation(TestCase):
         args = ("foo", "bar")
         "%" % args
         ''')
-
+        # consumes all memory until Python eventually segfaults
+        self.flakes('"%1000000000000f" % 1')
 
 class TestStringFormat(TestCase):
     def test_valid_string_format(self):


### PR DESCRIPTION
Verify simple cases, such as: `"%s: %s" % (foo, bar, baz)` and `"{foo}: {bar}".format(foo="foo", baaar="baz")`. 

This is done by asking Python to do the formatting, filling in the arguments with dummy objects.

The testing for `.format` string is skipped for Python3 but should be rather easy to add; I want to get an idea of whether you like the current approach first.

Resolves #148 