### PR TITLE
Travis with Xenial and py3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,21 @@
 language: python
 cache: pip
-python:
-  - 2.7
-  - 3.4
-  - 3.5
-  - 3.6
-  - nightly
-  - pypy
-  - pypy-5.3
-  - pypy3
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
+    - python: pypy
+    - python: pypy-5.3
+    - python: pypy3
+    - python: 3.7
+      dist: xenial
+    - python: nightly
+      dist: xenial
 install:
   - pip install --upgrade .
   - pip list
 script:
   - python setup.py test -q
   - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then pip install flake8==2.1.0 pep8==1.5.6 && flake8 --version && flake8 pyflakes setup.py; fi
-sudo: false

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skip_missing_interpreters = True
 envlist =
-    py27,py34,py35,py36,pypy,pypy3
+    py27,py34,py35,py36,py37,pypy,pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
Switch Travis from Ubuntu Trusty to Xenial and also test on cpython 3.7
Should fix the travis issues in https://github.com/PyCQA/pyflakes/pull/374