### PR TITLE
Mark SubmoduleImportation imported with Importation with alias as used

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -818,6 +818,16 @@ class Checker(object):
 
             try:
                 scope[name].used = (self.scope, node)
+
+                # if the name of SubImportation is same as
+                # alias of other Importation and the alias
+                # is used, SubImportation also should be marked as used.
+                n = scope[name]
+                if isinstance(n, Importation) and n._has_alias():
+                    try:
+                        scope[n.fullName].used = (self.scope, node)
+                    except KeyError:
+                        pass
             except KeyError:
                 pass
             else:

--- a/pyflakes/test/test_imports.py
+++ b/pyflakes/test/test_imports.py
@@ -887,6 +887,22 @@ class Test(TestCase):
         fu.x
         ''')
 
+    def test_used_package_with_submodule_import_of_alias(self):
+        """
+        Usage of package by alias marks submodule imports as used.
+        """
+        self.flakes('''
+        import foo as f
+        import foo.bar
+        f.bar.do_something()
+        ''')
+
+        self.flakes('''
+        import foo as f
+        import foo.bar.blah
+        f.bar.blah.do_something()
+        ''')
+
     def test_unused_package_with_submodule_import(self):
         """
         When a package and its submodule are imported, only report once.


### PR DESCRIPTION
If the name of SubmoduleImportation is same with the alias of other Importation
and it is used, the SubmoduleImportation should be marked as used, too.

Fixes https://github.com/PyCQA/pyflakes/issues/298