### PR TITLE
Mark Importation with underscore alias as used

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -785,7 +785,7 @@ class Checker(object):
 
         if value.name in self.scope:
             # then assume the rebound name is used as a global or within a loop
-            value.used = self.scope[value.name].used
+            value.used = value.used or self.scope[value.name].used
 
         self.scope[value.name] = value
 
@@ -1429,6 +1429,10 @@ class Checker(object):
             else:
                 name = alias.asname or alias.name
                 importation = Importation(name, node, alias.name)
+
+            if alias.asname == '_':
+                importation.used = True
+
             self.addBinding(node, importation)
 
     def IMPORTFROM(self, node):
@@ -1461,6 +1465,10 @@ class Checker(object):
             else:
                 importation = ImportationFrom(name, node,
                                               module, alias.name)
+
+            if alias.asname == '_':
+                importation.used = True
+
             self.addBinding(node, importation)
 
     def TRY(self, node):

--- a/pyflakes/test/test_imports.py
+++ b/pyflakes/test/test_imports.py
@@ -94,13 +94,6 @@ class TestImportationObject(TestCase):
         assert binding.source_statement == 'from __future__ import print_function'
         assert str(binding) == '__future__.print_function'
 
-    def test_unusedImport_underscore(self):
-        """
-        The magic underscore var should be reported as unused when used as an
-        import alias.
-        """
-        self.flakes('import fu as _', m.UnusedImport)
-
 
 class Test(TestCase):
 
@@ -142,6 +135,12 @@ class Test(TestCase):
         self.flakes('from moo import fu as moo; moo')
         self.flakes('import fu as fu; fu')
         self.flakes('import fu.bar as fu; fu')
+
+    def test_aliasedImportUnderscore(self):
+        """If the alias is underscore(_), mark as used."""
+        self.flakes('from fu import bar as _')
+        self.flakes('import fu as _')
+        self.flakes('import fu.bar as _')
 
     def test_usedImport(self):
         self.flakes('import fu; print(fu)')


### PR DESCRIPTION
If the importation has underscore alias like:
`from fu import bar as _`
it should be ignored from checking.

Closes https://github.com/PyCQA/pyflakes/issues/366