### PR TITLE
Update TravisCI to use flake8 3.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ install:
   - pip list
 script:
   - python setup.py test -q
-  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then pip install flake8==2.1.0 pep8==1.5.6 && flake8 --version && flake8 pyflakes setup.py; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then pip install flake8==3.6.0 pep8==1.5.6 && flake8 --version && flake8 pyflakes setup.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ install:
   - pip list
 script:
   - python setup.py test -q
-  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then pip install flake8==3.6.0 pep8==1.5.6 && flake8 --version && flake8 pyflakes setup.py; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then pip install flake8==3.6.0 pycodestyle==2.4.0 && flake8 --version && flake8 pyflakes setup.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ install:
   - pip list
 script:
   - python setup.py test -q
-  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then pip install flake8==3.6.0 pycodestyle==2.4.0 && flake8 --version && flake8 pyflakes setup.py; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" != "nightly" ]; then pip install flake8==3.6.0 && flake8 --version && flake8 pyflakes setup.py; fi

--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -10,6 +10,8 @@ import doctest
 import os
 import sys
 
+from pyflakes import messages
+
 PY2 = sys.version_info < (3, 0)
 PY34 = sys.version_info < (3, 5)    # Python 2.7 to 3.4
 try:
@@ -19,8 +21,6 @@ except AttributeError:
     PYPY = False
 
 builtin_vars = dir(__import__('__builtin__' if PY2 else 'builtins'))
-
-from pyflakes import messages
 
 
 if PY2:
@@ -211,8 +211,8 @@ class VariableKey(object):
 
     def __eq__(self, compare):
         return (
-            compare.__class__ == self.__class__
-            and compare.name == self.name
+            compare.__class__ == self.__class__ and
+            compare.name == self.name
         )
 
     def __hash__(self):
@@ -461,11 +461,11 @@ class FunctionScope(Scope):
         Return a generator for the assignments which have not been used.
         """
         for name, binding in self.items():
-            if (not binding.used
-                    and name != '_'  # see issue #202
-                    and name not in self.globals
-                    and not self.usesLocals
-                    and isinstance(binding, Assignment)):
+            if (not binding.used and
+                    name != '_' and  # see issue #202
+                    name not in self.globals and
+                    not self.usesLocals and
+                    isinstance(binding, Assignment)):
                 yield name, binding
 
 
@@ -1221,8 +1221,8 @@ class Checker(object):
         # Locate the name in locals / function / globals scopes.
         if isinstance(node.ctx, (ast.Load, ast.AugLoad)):
             self.handleNodeLoad(node)
-            if (node.id == 'locals' and isinstance(self.scope, FunctionScope)
-                    and isinstance(node.parent, ast.Call)):
+            if (node.id == 'locals' and isinstance(self.scope, FunctionScope) and
+                    isinstance(node.parent, ast.Call)):
                 # we are doing locals() call in current scope
                 self.scope.usesLocals = True
         elif isinstance(node.ctx, (ast.Store, ast.AugStore, ast.Param)):

--- a/tox.ini
+++ b/tox.ini
@@ -6,12 +6,13 @@ envlist =
 [testenv]
 deps =
 commands =
-    pip install flake8==2.1.0 pep8==1.5.6
+    pip install flake8==3.6.0 pep8==1.5.6
     flake8 --version
     python setup.py test -q
     flake8 pyflakes setup.py
 
 [flake8]
 select = E,F,W
+ignore=W504
 builtins = unicode
 max_line_length = 89

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,6 @@ commands =
 
 [flake8]
 select = E,F,W
-ignore=W504
+ignore = W504
 builtins = unicode
 max_line_length = 89

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,8 @@ envlist =
     py27,py34,py35,py36,py37,pypy,pypy3
 
 [testenv]
-deps =
+deps = flake8==3.6.0
 commands =
-    pip install flake8==3.6.0 pycodestyle==2.4.0
-    flake8 --version
     python setup.py test -q
     flake8 pyflakes setup.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
 [testenv]
 deps =
 commands =
-    pip install flake8==3.6.0 pep8==1.5.6
+    pip install flake8==3.6.0 pycodestyle==2.4.0
     flake8 --version
     python setup.py test -q
     flake8 pyflakes setup.py


### PR DESCRIPTION
Update TravisCI & `tox.ini` to use v3.6.0 in flake8 rather than v2.1.0 which is 4 years old.

Update `tox.ini` to ignore W504. This is ignored by default in flake8 but it is enabled by the `select`. *W503* and *W504* are opposites of one another and determines when to break with a statement and an operator.  PEP8 recommends breaking **after** binary operator (they originally recommended breaking before but changed).

Fix some expressions that break before binary operators.

Move import statement to top to fix another warning.

Change pep8 to pycodestyle and bump version