### PR TITLE
Remove impossible except UnicodeError

### DIFF
--- a/pyflakes/api.py
+++ b/pyflakes/api.py
@@ -91,9 +91,6 @@ def checkPath(filename, reporter=None):
     try:
         with open(filename, 'rb') as f:
             codestr = f.read()
-    except UnicodeError:
-        reporter.unexpectedError(filename, 'problem decoding source')
-        return 1
     except IOError:
         msg = sys.exc_info()[1]
         reporter.unexpectedError(filename, msg.args[1])


### PR DESCRIPTION
reading a file in binary mode (`rb`) does not involve unicode