### PR TITLE
Warn about return inside finally blocks

### DIFF
--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -182,6 +182,15 @@ class ReturnOutsideFunction(Message):
     message = '\'return\' outside function'
 
 
+class ReturnInsideFinallyBlock(Message):
+    """
+    Indicates a `return` statement inside a finally block, which will cause the
+    try/except block to terminate without the exception, hence loosing the
+    exception information
+    """
+    message = '\'return\' inside \'finally\' block will supress exceptions'
+
+
 class YieldOutsideFunction(Message):
     """
     Indicates a yield or yield from statement outside of a function/method.

--- a/pyflakes/test/test_return_in_finally.py
+++ b/pyflakes/test/test_return_in_finally.py
@@ -1,0 +1,110 @@
+
+from pyflakes import messages as m
+from pyflakes.test.harness import TestCase
+
+
+class Test(TestCase):
+    def test_return(self):
+        self.flakes('''
+        def a(): pass
+        def b():
+            try:
+                a()
+            finally:
+                return
+        ''', m.ReturnInsideFinallyBlock)
+
+    def test_returnWithValue(self):
+        self.flakes('''
+        def a():
+            try:
+                x = 1
+            finally:
+                return x
+        ''', m.ReturnInsideFinallyBlock)
+
+    def test_returnInNestedTry1(self):
+        self.flakes('''
+        def a():
+            try:
+                pass
+            finally:
+                try:
+                    return
+                except:
+                    pass
+        ''', m.ReturnInsideFinallyBlock)
+
+    def test_returnInNestedTry2(self):
+        self.flakes('''
+        def a():
+            try:
+                pass
+            finally:
+                try:
+                    pass
+                except:
+                    return
+        ''', m.ReturnInsideFinallyBlock)
+
+    def test_returnInNestedTry3(self):
+        self.flakes('''
+        def a():
+            try:
+                pass
+            finally:
+                try:
+                    pass
+                finally:
+                    return
+        ''', m.ReturnInsideFinallyBlock)
+
+    def test_returnInIf(self):
+        self.flakes('''
+        def a(): pass
+        def b():
+            try:
+                a()
+            finally:
+                if a():
+                    return
+                pass
+        ''', m.ReturnInsideFinallyBlock)
+
+    def test_returnInDeepIf(self):
+        self.flakes('''
+        def a(): pass
+        def b():
+            try:
+                raise ValueError()
+            except ValueError:
+                pass
+            finally:
+                if a():
+                    while a():
+                        for _ in a():
+                            return
+                pass
+        ''', m.ReturnInsideFinallyBlock)
+
+    def test_returnInNestedFunction(self):
+        self.flakes('''
+        def a():
+            try:
+                raise ValueError()
+            finally:
+                def b():
+                    return
+                pass
+        ''')
+
+    def test_returnInNestedClass(self):
+        self.flakes('''
+        def a():
+            try:
+                raise ValueError()
+            finally:
+                class B:
+                    def b(self):
+                        return
+        ''')


### PR DESCRIPTION
Issue #404

Returns inside finally blocks will suppress exceptions. Exceptions should be
suppressed explicitly in their except blocks. To break the flow in a finally block, refactor
it not to rely on the return.