### PR TITLE
Allow star args in type comments

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -1037,7 +1037,10 @@ class Checker(object):
             comment = comment.split(':', 1)[1].strip()
             func_match = TYPE_FUNC_RE.match(comment)
             if func_match:
-                parts = (func_match.group(1), func_match.group(2).strip())
+                parts = (
+                    func_match.group(1).replace('*', ''),
+                    func_match.group(2).strip(),
+                )
             else:
                 parts = (comment,)
 

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -231,6 +231,14 @@ class TestTypeAnnotations(TestCase):
             return a + b
         """)
 
+    def test_typeCommentsStarArgs(self):
+        self.flakes("""
+        from mod import A, B, C, D
+        def f(a, *b, **c):
+            # type: (A, *B, **C) -> D
+            return a + b
+        """)
+
     def test_typeCommentsFullSignatureWithDocstring(self):
         self.flakes('''
         from mod import A, B, C, D


### PR DESCRIPTION
Found while trying out the release on [this file](https://github.com/lyft/awspricing/blob/23493d2c397da9dcffcf3b598df5b5d32f303121/awspricing/constants.py#L14)