### PR TITLE
Include column numbers with all error messages

### DIFF
--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -10,10 +10,10 @@ class Message(object):
     def __init__(self, filename, loc):
         self.filename = filename
         self.lineno = loc.lineno
-        self.col = getattr(loc, 'col_offset', -1)
+        self.col = getattr(loc, 'col_offset', -1) + 1
 
     def __str__(self):
-        column = '%s:' % self.col if self.col != -1 else ''
+        column = '%s:' % self.col if self.col else ''
         return '%s:%s:%s %s' % (self.filename, self.lineno, column,
                                  self.message % self.message_args)
 

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -10,11 +10,10 @@ class Message(object):
     def __init__(self, filename, loc):
         self.filename = filename
         self.lineno = loc.lineno
-        self.col = getattr(loc, 'col_offset', -1) + 1
+        self.col = getattr(loc, 'col_offset', 0)
 
     def __str__(self):
-        column = '%s:' % self.col if self.col else ''
-        return '%s:%s:%s %s' % (self.filename, self.lineno, column,
+        return '%s:%s:%s %s' % (self.filename, self.lineno, self.col+1,
                                  self.message % self.message_args)
 
 

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -13,11 +13,9 @@ class Message(object):
         self.col = getattr(loc, 'col_offset', -1)
 
     def __str__(self):
-        if self.col != -1:
-            return '%s:%s:%s: %s' % (self.filename, self.lineno, self.col,
-                                  self.message % self.message_args)
-        return '%s:%s: %s' % (self.filename, self.lineno,
-                              self.message % self.message_args)
+        column = '%s:' % self.col if self.col != -1 else ''
+        return '%s:%s:%s %s' % (self.filename, self.lineno, column,
+                                 self.message % self.message_args)
 
 
 class UnusedImport(Message):

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -14,7 +14,7 @@ class Message(object):
 
     def __str__(self):
         return '%s:%s:%s %s' % (self.filename, self.lineno, self.col+1,
-                                 self.message % self.message_args)
+                                self.message % self.message_args)
 
 
 class UnusedImport(Message):

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -10,9 +10,12 @@ class Message(object):
     def __init__(self, filename, loc):
         self.filename = filename
         self.lineno = loc.lineno
-        self.col = getattr(loc, 'col_offset', 0)
+        self.col = getattr(loc, 'col_offset', -1)
 
     def __str__(self):
+        if self.col != -1:
+            return '%s:%s:%s: %s' % (self.filename, self.lineno, self.col,
+                                  self.message % self.message_args)
         return '%s:%s: %s' % (self.filename, self.lineno,
                               self.message % self.message_args)
 


### PR DESCRIPTION
As long as the node passed to the message has a col_offset, it is included in
the message. There is already a precedent of printing the column number for
syntax errors.

This changes the API slightly, in that if col_offset is not present on the
node, the message.col is now -1 instead of 0. Otherwise, there would be no way
to distinguish between errors that have no column number and errors with a
column number 0. If this doesn't seem like an acceptable change, I can revert
it, and either always use 0 as the default, or use a separate attribute to
indicate if the message.col is the "real" column number.

I haven't yet tested everything, but I'm not even sure if there are any nodes
that don't have a col_offset. There don't appear to be any represented in the
test suite.

I haven't added any tests yet. I want to get feedback first if this is a desired change. 

Fixes https://github.com/PyCQA/pyflakes/issues/158, fixes https://github.com/PyCQA/pyflakes/issues/425.