### PR TITLE
Remove unnecessary `else`

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -538,8 +538,8 @@ def is_typing_overload(value, scope_stack):
                     isinstance(scope[name], ImportationFrom) and
                     scope[name].fullName == 'typing.overload'
                 )
-        else:
-            return False
+
+        return False
 
     def is_typing_overload_decorator(node):
         return (


### PR DESCRIPTION
This merely simplifies the code by removing an unnecessary `else`.