### PR TITLE
String formatting linting

### DIFF
--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -306,3 +306,59 @@ class StringDotFormatInvalidFormat(Message):
     def __init__(self, filename, loc, error):
         Message.__init__(self, filename, loc)
         self.message_args = (error,)
+
+
+class PercentFormatInvalidFormat(Message):
+    message = "'...' %% ... has invalid format string: %s"
+
+    def __init__(self, filename, loc, error):
+        Message.__init__(self, filename, loc)
+        self.message_args = (error,)
+
+
+class PercentFormatMixedPositionalAndNamed(Message):
+    message = "'...' %% ... has mixed positional and named placeholders"
+
+
+class PercentFormatUnsupportedFormatCharacter(Message):
+    message = "'...' %% ... has unsupported format character %r"
+
+    def __init__(self, filename, loc, c):
+        Message.__init__(self, filename, loc)
+        self.message_args = (c,)
+
+
+class PercentFormatPositionalCountMismatch(Message):
+    message = "'...' %% ... has %d placeholder(s) but %d substitution(s)"
+
+    def __init__(self, filename, loc, n_placeholders, n_substitutions):
+        Message.__init__(self, filename, loc)
+        self.message_args = (n_placeholders, n_substitutions)
+
+
+class PercentFormatExtraNamedArguments(Message):
+    message = "'...' %% ... has unused named argument(s): %s"
+
+    def __init__(self, filename, loc, extra_keywords):
+        Message.__init__(self, filename, loc)
+        self.message_args = (extra_keywords,)
+
+
+class PercentFormatMissingArgument(Message):
+    message = "'...' %% ... is missing argument(s) for placeholder(s): %s"
+
+    def __init__(self, filename, loc, missing_arguments):
+        Message.__init__(self, filename, loc)
+        self.message_args = (missing_arguments,)
+
+
+class PercentFormatExpectedMapping(Message):
+    message = "'...' %% ... expected mapping but got sequence"
+
+
+class PercentFormatExpectedSequence(Message):
+    message = "'...' %% ... expected sequence but got mapping"
+
+
+class PercentFormatStarRequiresSequence(Message):
+    message = "'...' %% ... `*` specifier requires sequence"

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -266,3 +266,7 @@ class InvalidPrintSyntax(Message):
 
 class IsLiteral(Message):
     message = 'use ==/!= to compare str, bytes, and int literals'
+
+
+class FStringMissingPlaceholders(Message):
+    message = 'f-string is missing placeholders'

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -270,3 +270,39 @@ class IsLiteral(Message):
 
 class FStringMissingPlaceholders(Message):
     message = 'f-string is missing placeholders'
+
+
+class StringDotFormatExtraPositionalArguments(Message):
+    message = "'...'.format(...) has unused arguments at position(s): %s"
+
+    def __init__(self, filename, loc, extra_positions):
+        Message.__init__(self, filename, loc)
+        self.message_args = (extra_positions,)
+
+
+class StringDotFormatExtraNamedArguments(Message):
+    message = "'...'.format(...) has unused named argument(s): %s"
+
+    def __init__(self, filename, loc, extra_keywords):
+        Message.__init__(self, filename, loc)
+        self.message_args = (extra_keywords,)
+
+
+class StringDotFormatMissingArgument(Message):
+    message = "'...'.format(...) is missing argument(s) for placeholder(s): %s"
+
+    def __init__(self, filename, loc, missing_arguments):
+        Message.__init__(self, filename, loc)
+        self.message_args = (missing_arguments,)
+
+
+class StringDotFormatMixingAutomatic(Message):
+    message = "'...'.format(...) mixes automatic and manual numbering"
+
+
+class StringDotFormatInvalidFormat(Message):
+    message = "'...'.format(...) has invalid format string: %s"
+
+    def __init__(self, filename, loc, error):
+        Message.__init__(self, filename, loc)
+        self.message_args = (error,)

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -1755,6 +1755,41 @@ class TestUnusedAssignment(TestCase):
         ''')
 
 
+class TestStringFormatting(TestCase):
+
+    @skipIf(version_info < (3, 6), 'new in Python 3.6')
+    def test_f_string_without_placeholders(self):
+        self.flakes("f'foo'", m.FStringMissingPlaceholders)
+        self.flakes('''
+            f"""foo
+            bar
+            """
+        ''', m.FStringMissingPlaceholders)
+        self.flakes('''
+            print(
+                f'foo'
+                f'bar'
+            )
+        ''', m.FStringMissingPlaceholders)
+        # this is an "escaped placeholder" but not a placeholder
+        self.flakes("f'{{}}'", m.FStringMissingPlaceholders)
+        # ok: f-string with placeholders
+        self.flakes('''
+            x = 5
+            print(f'{x}')
+        ''')
+        # ok: f-string with format specifiers
+        self.flakes('''
+            x = 'a' * 90
+            print(f'{x:.8}')
+        ''')
+        # ok: f-string with multiple format specifiers
+        self.flakes('''
+            x = y = 5
+            print(f'{x:>2} {y:>2}')
+        ''')
+
+
 class TestAsyncStatements(TestCase):
 
     @skipIf(version_info < (3, 5), 'new in Python 3.5')


### PR DESCRIPTION
There's three classes of lint messages added here -- I'm happy to split out / reorder / etc. these commits as fit.   Also please suggest better names / messages -- these were my first-pass attempt at the messages 😆 

Resolves #148 

Supersedes #370 (CC @fperrin)

### f-strings

- f-strings without placeholders

### `'...'.format(...)`

- `'{}'.format(1, 2)` -- extra positional arguments
- `'{foo}'.format(foo=1, bar=2)` -- extra named arguments
- `'{} {}'.format(1)` -- placeholder missing argument (positional)
- `'{foo} {bar}'.format(foo=1)` -- placeholder missing argument (named)
- `'{} {1}'.format(1, 2)` -- switching between manual / automatic numbering
- `'{0} {}'.format(1, 2)` -- switching between manual / automatic numbering
- `'{'.format(1)` -- invalid format string

### `'...' % ...`

- `'%(foo)' % ()` -- invalid format string (missing the conversion type)
- `'%j' % ()` -- invalid format specifier (`j` is not a valid conversion type)
- `'%s %s' % (1, 2, 3)` -- positional count mismatch (too many args)
- `'%s %s' % (1,)` -- positional count mismatch (too few args)
- `'%(bar)s' % {'bar': 1, 'baz': 2}` -- extra named argument supplied
- `'%(bar)s %(baz)s' % {'bar': 1}` -- missing named argument
- `'%(bar)s' % (1, 2, 3)` -- expected mapping, but got sequence
- `'%s %s' % {'baz': 1}` -- expected sequence, got mapping

---

- Code for parsing `.format()` uses [`string.Formatter.parse`](https://docs.python.org/3/library/string.html#string.Formatter.parse)
- Code for parsing `%` format is lifted from [pyupgrade](https://github.com/asottile/pyupgrade): [here](https://github.com/asottile/pyupgrade/blob/cf4555014f9332ac06aebbca9dccfe75090be3d7/pyupgrade.py#L521-L578)