### PR TITLE
Fix NoneType has no attribute parent when handling doctests

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -1162,7 +1162,8 @@ class Checker(object):
         self.scopeStack = [self.scopeStack[0]]
         node_offset = self.offset or (0, 0)
         self.pushScope(DoctestScope)
-        self.addBinding(None, Builtin('_'))
+        if '_' not in self.scopeStack[0]:
+            self.addBinding(None, Builtin('_'))
         for example in examples:
             try:
                 tree = ast.parse(example.source, "<doctest>")

--- a/pyflakes/test/test_doctests.py
+++ b/pyflakes/test/test_doctests.py
@@ -433,6 +433,16 @@ class Test(TestCase):
             return 1
         ''')
 
+    def test_globalUnderscoreInDoctest(self):
+        self.flakes("""
+        from gettext import ugettext as _
+
+        def doctest_stuff():
+            '''
+                >>> pass
+            '''
+        """, m.UnusedImport)
+
 
 class TestOther(_DoctestMixin, TestOther):
     """Run TestOther with each test wrapped in a doctest."""


### PR DESCRIPTION
Do not define a special `_` name in doctest scope when the global scope already has a `_`.  This mirrors the way doctests actually work: the special `_` value is assigned only when a global of that name doesn't
already exist.

Fixes #421.