### PR TITLE
In PEP 484 type comments, allow text after "# type: ignore"

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -73,11 +73,13 @@ else:
     FOR_TYPES = (ast.For,)
     LOOP_TYPES = (ast.While, ast.For)
 
-# https://github.com/python/typed_ast/blob/55420396/ast27/Parser/tokenizer.c#L102-L104
+# https://github.com/python/typed_ast/blob/1.4.0/ast27/Parser/tokenizer.c#L102-L104
 TYPE_COMMENT_RE = re.compile(r'^#\s*type:\s*')
-# https://github.com/python/typed_ast/blob/55420396/ast27/Parser/tokenizer.c#L1400
-TYPE_IGNORE_RE = re.compile(TYPE_COMMENT_RE.pattern + r'ignore\s*(#|$)')
-# https://github.com/python/typed_ast/blob/55420396/ast27/Grammar/Grammar#L147
+# https://github.com/python/typed_ast/blob/1.4.0/ast27/Parser/tokenizer.c#L1408-L1413
+ASCII_NON_ALNUM = ''.join([chr(i) for i in range(128) if not chr(i).isalnum()])
+TYPE_IGNORE_RE = re.compile(
+    TYPE_COMMENT_RE.pattern + r'ignore([{}]|$)'.format(ASCII_NON_ALNUM))
+# https://github.com/python/typed_ast/blob/1.4.0/ast27/Grammar/Grammar#L147
 TYPE_FUNC_RE = re.compile(r'^(\(.*?\))\s*->\s*(.*)$')
 
 

--- a/pyflakes/test/test_checker.py
+++ b/pyflakes/test/test_checker.py
@@ -152,10 +152,6 @@ class CollectTypeCommentsTests(TestCase):
         ret = self._collect('x = 1 #type:int')
         self.assertSetEqual(ret, {(ast.Assign, ('#type:int',))})
 
-    def test_type_comment_starts_with_word_ignore(self):
-        ret = self._collect('x = 1 # type: ignore[T]')
-        self.assertSetEqual(ret, {(ast.Assign, ('# type: ignore[T]',))})
-
     def test_last_node_wins(self):
         """
         Test that when two typeable nodes are present on a line, the last

--- a/pyflakes/test/test_checker.py
+++ b/pyflakes/test/test_checker.py
@@ -152,6 +152,10 @@ class CollectTypeCommentsTests(TestCase):
         ret = self._collect('x = 1 #type:int')
         self.assertSetEqual(ret, {(ast.Assign, ('#type:int',))})
 
+    def test_type_comment_starts_with_word_ignore(self):
+        ret = self._collect('x = 1 # type: ignore[T]')
+        self.assertSetEqual(ret, set())
+
     def test_last_node_wins(self):
         """
         Test that when two typeable nodes are present on a line, the last

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -343,6 +343,27 @@ class TestTypeAnnotations(TestCase):
         # type: F
         """)
 
+    def test_typeIgnore(self):
+        self.flakes("""
+        a = 0  # type: ignore
+        b = 0  # type: ignore[excuse]
+        c = 0  # type: ignore=excuse
+        d = 0  # type: ignore [excuse]
+        e = 0  # type: ignore whatever
+        """)
+
+    def test_typeIgnoreBogus(self):
+        self.flakes("""
+        x = 1  # type: ignored
+        """, m.UndefinedName)
+
+    def test_typeIgnoreBogusUnicode(self):
+        error = (m.CommentAnnotationSyntaxError if version_info < (3,)
+                 else m.UndefinedName)
+        self.flakes("""
+        x = 2  # type: ignore\xc3
+        """, error)
+
     @skipIf(version_info < (3,), 'new in Python 3')
     def test_return_annotation_is_class_scope_variable(self):
         self.flakes("""


### PR DESCRIPTION
This is to support allowing typecheckers to implement ignores for
specific errors, using syntax like `# type: ignore=E1000` or
`# type: ignore[type-mismatch]` or some such.
mypy is about to add support for ignoring specific errors following
this design: https://github.com/python/mypy/issues/7239

Support for extra text in type comments was implemented
in CPython as https://bugs.python.org/issue36878
and in typed_ast as https://github.com/python/typed_ast/pull/116.