### PR TITLE
Add a structured list reporter to pyflakes.reporter

### DIFF
--- a/pyflakes/reporter.py
+++ b/pyflakes/reporter.py
@@ -76,7 +76,8 @@ class Reporter(object):
 
 
 class ListReporter(object):
-    """Simple reporter class that logs all entries to list of dictionaries with consistent structure."""
+    """Simple reporter class that logs all entries to list of
+    dictionaries with consistent structure."""
 
     def __init__(self):
         """

--- a/pyflakes/reporter.py
+++ b/pyflakes/reporter.py
@@ -75,6 +75,43 @@ class Reporter(object):
         self._stdout.write('\n')
 
 
+class ListReporter(object):
+    """Simple reporter class that logs all entries to list of dictionaries with consistent structure."""
+
+    def __init__(self):
+        """
+        Initialize empty list for entries.
+        """
+        self.entries = []
+
+    def unexpectedError(self, filename, msg):
+        self.entries.append({"message_class": "error",
+                             "message_type": "unexpected_error",
+                             "filename": filename,
+                             "lineno": None,
+                             "offset": None,
+                             "message": msg,
+                             "source": None, })
+
+    def syntaxError(self, filename, msg, lineno, offset, text):
+        self.entries.append({"message_class": "error",
+                             "message_type": "syntax_error",
+                             "filename": filename,
+                             "lineno": lineno,
+                             "offset": offset,
+                             "message": msg,
+                             "source": text, })
+
+    def flake(self, message):
+        self.entries.append({"message_class": "warning",
+                             "message_type": "flake_warning",
+                             "filename": message.filename,
+                             "lineno": message.lineno,
+                             "offset": message.col,
+                             "message": message.message % message.message_args,
+                             "source": None, })
+
+
 def _makeDefaultReporter():
     """
     Make a reporter that can be used when no reporter is specified.


### PR DESCRIPTION
Adding a simple reporter class to log to a list of dictionaries with a consistent format across all message types and sources:
* `message_class`: analogous to E/W/L, e.g., `"error"`
* `message_type`: more specific type or description, e.g., `"syntax_error"`
* `filename`: file name if provided, else None
* `lineno`: line number if provided, else None
* `message`: "message" from the perspective of the sender
* `source`: source code if provided, else None

Sample output:
```
>>> reporter = pyflakes.reporter.ListReporter()
>>> pyflakes.api.check(source_bytes, file_name, reporter)
>>> print(reporter.entries)
[{'message_class': 'warning',
  'message_type': 'flake_warning',
  'filename': '0-core-client-1.1.0a8/zeroos/core0/client/__init__.py',
  'lineno': 1,
  'offset': 0,
  'message': "'.client.Client' imported but unused",
  'source': None},
 {'message_class': 'warning',
  'message_type': 'flake_warning',
  'filename': '0-core-client-1.1.0a8/zeroos/core0/client/__init__.py',
  'lineno': 1,
  'offset': 0,
  'message': "'.client.ResultError' imported but unused",
  'source': None},
 {'message_class': 'warning',
  'message_type': 'flake_warning',
  'filename': '0-core-client-1.1.0a8/zeroos/core0/client/__init__.py',
  'lineno': 1,
  'offset': 0,
  'message': "'.client.JobNotFoundError' imported but unused",
  'source': None},
 {'message_class': 'warning',
  'message_type': 'flake_warning',
  'filename': '0-core-client-1.1.0a8/zeroos/core0/client/client.py',
  'lineno': 742,
  'offset': 8,
  'message': "'raise NotImplemented' should be 'raise NotImplementedError'",
  'source': None}]
```