### PR TITLE
Support typing_extensions.overload in addition to typing.overload

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -622,7 +622,9 @@ def is_typing_overload(value, scope_stack):
             if name in scope:
                 return (
                     isinstance(scope[name], ImportationFrom) and
-                    scope[name].fullName == 'typing.overload'
+                    scope[name].fullName in (
+                        'typing.overload', 'typing_extensions.overload',
+                    )
                 )
 
         return False

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -39,6 +39,23 @@ class TestTypeAnnotations(TestCase):
             return s
         """)
 
+    def test_typingExtensionsOverload(self):
+        """Allow intentional redefinitions via @typing_extensions.overload"""
+        self.flakes("""
+        from typing_extensions import overload
+
+        @overload
+        def f(s):  # type: (None) -> None
+            pass
+
+        @overload
+        def f(s):  # type: (int) -> int
+            pass
+
+        def f(s):
+            return s
+        """)
+
     def test_overload_with_multiple_decorators(self):
         self.flakes("""
             from typing import overload


### PR DESCRIPTION
They are synonyms and typing_extensions.overloads works on 3.5.1.