### PR TITLE
Adjust tests for different SyntaxError offsets for pypy7.1.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,25 +2,17 @@
 install:
   - python -m pip install --upgrade tox virtualenv
 
-  # Fetch the three main PyPy releases
-  - ps: (New-Object Net.WebClient).DownloadFile('https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-win32.zip', "$env:appveyor_build_folder\pypy-2.6.1-win32.zip")
-  - ps: 7z x pypy-2.6.1-win32.zip | Out-Null
-  - move pypy-2.6.1-win32 C:\
+  - ps: (New-Object Net.WebClient).DownloadFile('https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.1.1-win32.zip', "$env:appveyor_build_folder\pypy2.7-v7.1.1-win32.zip")
+  - ps: 7z x pypy2.7-v7.1.1-win32.zip | Out-Null
+  - move pypy2.7-v7.1.1-win32 C:\
+  - 'SET PATH=C:\pypy2.7-v7.1.1-win32\;%PATH%'
 
-  - ps: (New-Object Net.WebClient).DownloadFile('https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.1-win32.zip', "$env:appveyor_build_folder\pypy2-v5.3.1-win32.zip")
-  - ps: 7z x pypy2-v5.3.1-win32.zip | Out-Null
-  - move pypy2-v5.3.1-win32 C:\
-
-  # TODO: pypy 6.0.0 offsets are different
-  #- ps: (New-Object Net.WebClient).DownloadFile('https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-win32.zip', "$env:appveyor_build_folder\pypy3-v6.0.0-win32.zip")
-  #- ps: 7z x pypy3-v6.0.0-win32.zip | Out-Null
-  #- move pypy3-v6.0.0-win32 C:\
+  - ps: (New-Object Net.WebClient).DownloadFile('https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.1-win32.zip', "$env:appveyor_build_folder\pypy3.6-v7.1.1-win32.zip")
+  - ps: 7z x pypy3.6-v7.1.1-win32.zip | Out-Null
+  - move pypy3.6-v7.1.1-win32 C:\
+  - 'SET PATH=C:\pypy3.6-v7.1.1-win32\;%PATH%'
 
 build: off
 
 test_script:
   - python -m tox
-  - C:\pypy-2.6.1-win32\pypy -m unittest discover pyflakes
-  - C:\pypy2-v5.3.1-win32\pypy -m unittest discover pyflakes
-  # TODO: pypy 6.0.0 offsets are different
-  #- C:\pypy3-v6.0.0-win32\pypy3 -m unittest discover pyflakes

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ matrix:
     - python: 3.5
     - python: 3.6
     - python: pypy
-    - python: pypy-5.3
     - python: pypy3
     - python: 3.7
       dist: xenial

--- a/pyflakes/test/test_doctests.py
+++ b/pyflakes/test/test_doctests.py
@@ -328,7 +328,9 @@ class Test(TestCase):
             m.DoctestSyntaxError).messages
         exc = exceptions[0]
         self.assertEqual(exc.lineno, 4)
-        if sys.version_info >= (3, 8):
+        if PYPY:
+            self.assertEqual(exc.col, 27)
+        elif sys.version_info >= (3, 8):
             self.assertEqual(exc.col, 18)
         else:
             self.assertEqual(exc.col, 26)
@@ -339,12 +341,14 @@ class Test(TestCase):
         exc = exceptions[1]
         self.assertEqual(exc.lineno, 5)
         if PYPY:
-            self.assertEqual(exc.col, 13)
+            self.assertEqual(exc.col, 14)
         else:
             self.assertEqual(exc.col, 16)
         exc = exceptions[2]
         self.assertEqual(exc.lineno, 6)
-        if PYPY or sys.version_info >= (3, 8):
+        if PYPY:
+            self.assertEqual(exc.col, 14)
+        elif sys.version_info >= (3, 8):
             self.assertEqual(exc.col, 13)
         else:
             self.assertEqual(exc.col, 18)
@@ -358,7 +362,9 @@ class Test(TestCase):
             """
         ''', m.DoctestSyntaxError).messages[0]
         self.assertEqual(exc.lineno, 5)
-        if PYPY or sys.version_info >= (3, 8):
+        if PYPY:
+            self.assertEqual(exc.col, 14)
+        elif sys.version_info >= (3, 8):
             self.assertEqual(exc.col, 13)
         else:
             self.assertEqual(exc.col, 16)
@@ -377,7 +383,10 @@ class Test(TestCase):
             m.DoctestSyntaxError,
             m.UndefinedName).messages
         self.assertEqual(exc1.lineno, 6)
-        self.assertEqual(exc1.col, 19)
+        if PYPY:
+            self.assertEqual(exc1.col, 20)
+        else:
+            self.assertEqual(exc1.col, 19)
         self.assertEqual(exc2.lineno, 7)
         self.assertEqual(exc2.col, 12)
 


### PR DESCRIPTION
- noticed in #467
- travis-ci doesn't seem to have a pypy-5.3 distribution any more so I dropped that
- the pypy / pypy3 targets give latest, at the time this is 7.1.1