### PR TITLE
Allow complex expressions in the ignore part of a type comment

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -83,7 +83,7 @@ TYPE_COMMENT_RE = re.compile(r'^#\s*type:\s*')
 # https://github.com/python/typed_ast/blob/1.4.0/ast27/Parser/tokenizer.c#L1408-L1413
 ASCII_NON_ALNUM = ''.join([chr(i) for i in range(128) if not chr(i).isalnum()])
 TYPE_IGNORE_RE = re.compile(
-    TYPE_COMMENT_RE.pattern + r'ignore([{}]|$)'.format(ASCII_NON_ALNUM))
+    TYPE_COMMENT_RE.pattern + r'ignore([{} ,-]|$)'.format(ASCII_NON_ALNUM))
 # https://github.com/python/typed_ast/blob/1.4.0/ast27/Grammar/Grammar#L147
 TYPE_FUNC_RE = re.compile(r'^(\(.*?\))\s*->\s*(.*)$')
 

--- a/pyflakes/test/test_checker.py
+++ b/pyflakes/test/test_checker.py
@@ -155,6 +155,12 @@ class CollectTypeCommentsTests(TestCase):
     def test_type_comment_starts_with_word_ignore(self):
         ret = self._collect('x = 1 # type: ignore[T]')
         self.assertSetEqual(ret, set())
+        ret = self._collect('x = 1 # type: ignore[code-1]')
+        self.assertSetEqual(ret, set())
+        ret = self._collect('x = 1 # type: ignore[code-1, code-2]')
+        self.assertSetEqual(ret, set())
+        ret = self._collect('x = 1 # type: ignore[ code-1 , code-2 ]')
+        self.assertSetEqual(ret, set())
 
     def test_last_node_wins(self):
         """


### PR DESCRIPTION
Mypy allows several error codes with minus signs in them, like `# type: ignore[comparison-overlap]`. Also, it allows multiple error codes in one line, like `# type: ignore[name-defined, attr-defined]`. These cases will trigger syntax errors in pyflakes. I am not sure about whether there is a standard about the syntax. At least, we can make it compatible.

See also:
https://mypy.readthedocs.io/en/latest/error_code_list2.html
https://github.com/python/mypy/blob/master/test-data/unit/check-errorcodes.test
