### PR TITLE
Deprecate optparse in favor of argparse

### DIFF
--- a/pyflakes/api.py
+++ b/pyflakes/api.py
@@ -201,7 +201,7 @@ def main(prog=None, args=None):
 
     parser = argparse.ArgumentParser(prog=prog,
                                      description='Check Python source files for errors')
-    parser.add_argument('--version', action='version', version=_get_version())
+    parser.add_argument('-V', '--version', action='version', version=_get_version())
     parser.add_argument('path', nargs='*',
                         help='Path(s) of Python file(s) to check. STDIN if not given.')
     args = parser.parse_args(args=args).path

--- a/pyflakes/api.py
+++ b/pyflakes/api.py
@@ -193,14 +193,18 @@ def _get_version():
 
 def main(prog=None, args=None):
     """Entry point for the script "pyflakes"."""
-    import optparse
+    import argparse
 
     # Handle "Keyboard Interrupt" and "Broken pipe" gracefully
     _exitOnSignal('SIGINT', '... stopped')
     _exitOnSignal('SIGPIPE', 1)
 
-    parser = optparse.OptionParser(prog=prog, version=_get_version())
-    (__, args) = parser.parse_args(args=args)
+    parser = argparse.ArgumentParser(prog=prog,
+                                     description='Check Python source files for errors')
+    parser.add_argument('--version', action='version', version=_get_version())
+    parser.add_argument('path', nargs='*',
+                        help='Path(s) of Python file(s) to check. STDIN if not given.')
+    args = parser.parse_args(args=args).path
     reporter = modReporter._makeDefaultReporter()
     if args:
         warnings = checkRecursive(args, reporter)


### PR DESCRIPTION
According to [the official docs](https://docs.python.org/3.8/library/optparse.html), the optparse standard library has been deprecated since Python 3.2, in favor of the argparse standard library.

This pull request includes a commit that removes usage of optparse from pyflakes and uses argparse in its place. It also adds a couple of short descriptive strings for pyflakes usage via the command-line: a very brief one-liner describing pyflakes (taken from the README) and some information about the (optional) command-line arguments. Feel free to improve them, of course.

Note: this is my first fork, my first pull request, my first real usage of GitHub. I'm also relatively new to git and Python. Let me know if anything in my code or in the way I'm collaborating/etc. should be changed. I'm always trying to improve. (And happy new year!)