### PR TITLE
Fix bug in async function scope checking

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -748,7 +748,7 @@ class Checker(object):
         ast.DictComp: GeneratorScope,
     }
     if PY35_PLUS:
-        _ast_node_scope[ast.AsyncFunctionDef] = FunctionScope,
+        _ast_node_scope[ast.AsyncFunctionDef] = FunctionScope
 
     nodeDepth = 0
     offset = None

--- a/pyflakes/test/test_code_segment.py
+++ b/pyflakes/test/test_code_segment.py
@@ -1,7 +1,9 @@
+from sys import version_info
+
 from pyflakes import messages as m
 from pyflakes.checker import (FunctionScope, ClassScope, ModuleScope,
                               Argument, FunctionDefinition, Assignment)
-from pyflakes.test.harness import TestCase
+from pyflakes.test.harness import TestCase, skipIf
 
 
 class TestCodeSegments(TestCase):
@@ -125,6 +127,7 @@ class TestCodeSegments(TestCase):
         self.assertIsInstance(function_scope_bar['h'], Argument)
         self.assertIsInstance(function_scope_bar['i'], Argument)
 
+    @skipIf(version_info < (3, 5), 'new in Python 3.5')
     def test_scope_async_function(self):
         checker = self.flakes('''
         async def foo(a, b=1, *d, **e):

--- a/pyflakes/test/test_code_segment.py
+++ b/pyflakes/test/test_code_segment.py
@@ -129,47 +129,4 @@ class TestCodeSegments(TestCase):
 
     @skipIf(version_info < (3, 5), 'new in Python 3.5')
     def test_scope_async_function(self):
-        checker = self.flakes('''
-        async def foo(a, b=1, *d, **e):
-            def bar(f, g=1, *h, **i):
-                pass
-        ''', is_segment=True)
-
-        scopes = checker.deadScopes
-        module_scopes = [
-            scope for scope in scopes if scope.__class__ is ModuleScope]
-        function_scopes = [
-            scope for scope in scopes if scope.__class__ is FunctionScope]
-
-        # Ensure module scope is not present because we are analysing
-        # the inner contents of foo
-        self.assertEqual(len(module_scopes), 0)
-        self.assertEqual(len(function_scopes), 2)
-
-        function_scope_foo = function_scopes[1]
-        function_scope_bar = function_scopes[0]
-
-        self.assertIsInstance(function_scope_foo, FunctionScope)
-        self.assertIsInstance(function_scope_bar, FunctionScope)
-
-        self.assertIn('a', function_scope_foo)
-        self.assertIn('b', function_scope_foo)
-        self.assertIn('d', function_scope_foo)
-        self.assertIn('e', function_scope_foo)
-        self.assertIn('bar', function_scope_foo)
-
-        self.assertIn('f', function_scope_bar)
-        self.assertIn('g', function_scope_bar)
-        self.assertIn('h', function_scope_bar)
-        self.assertIn('i', function_scope_bar)
-
-        self.assertIsInstance(function_scope_foo['bar'], FunctionDefinition)
-        self.assertIsInstance(function_scope_foo['a'], Argument)
-        self.assertIsInstance(function_scope_foo['b'], Argument)
-        self.assertIsInstance(function_scope_foo['d'], Argument)
-        self.assertIsInstance(function_scope_foo['e'], Argument)
-
-        self.assertIsInstance(function_scope_bar['f'], Argument)
-        self.assertIsInstance(function_scope_bar['g'], Argument)
-        self.assertIsInstance(function_scope_bar['h'], Argument)
-        self.assertIsInstance(function_scope_bar['i'], Argument)
+        self.flakes('async def foo(): pass', is_segment=True)


### PR DESCRIPTION
Previously attempting to check an async function scoped tree would immediately error because tuples are not callable.

The test added here is a direct copy of `test_scope_function` as I'm not sure what (if anything) should specifically be tested for async functions, though it serves to prove the fix. Happy to change this if there are other things we should be checking there.