### PR TITLE
Add a check for if statement conditions which are non-empty tuples

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -1364,14 +1364,14 @@ class Checker(object):
         pass
 
     # "stmt" type nodes
-    DELETE = PRINT = FOR = ASYNCFOR = WHILE = IF = WITH = WITHITEM = \
+    DELETE = PRINT = FOR = ASYNCFOR = WHILE = WITH = WITHITEM = \
         ASYNCWITH = ASYNCWITHITEM = TRYFINALLY = EXEC = \
         EXPR = ASSIGN = handleChildren
 
     PASS = ignore
 
     # "expr" type nodes
-    BOOLOP = UNARYOP = IFEXP = SET = \
+    BOOLOP = UNARYOP = SET = \
         REPR = ATTRIBUTE = \
         STARRED = NAMECONSTANT = NAMEDEXPR = handleChildren
 
@@ -1727,6 +1727,13 @@ class Checker(object):
                             key,
                         )
         self.handleChildren(node)
+
+    def IF(self, node):
+        if isinstance(node.test, ast.Tuple) and node.test.elts != []:
+            self.report(messages.IfTuple, node)
+        self.handleChildren(node)
+
+    IFEXP = IF
 
     def ASSERT(self, node):
         if isinstance(node.test, ast.Tuple) and node.test.elts != []:

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -235,7 +235,7 @@ class TooManyExpressionsInStarredAssignment(Message):
 
 class IfTuple(Message):
     """
-    Conditional test is a tuple, which are always True.
+    Conditional test is a non-empty tuple literal, which are always True.
     """
     message = '\'if tuple literal\' is always true, perhaps remove accidental comma?'
 

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -233,6 +233,13 @@ class TooManyExpressionsInStarredAssignment(Message):
     message = 'too many expressions in star-unpacking assignment'
 
 
+class IfTuple(Message):
+    """
+    Conditional test is a tuple, which are always True.
+    """
+    message = 'if condition is always true, perhaps remove parentheses?'
+
+
 class AssertTuple(Message):
     """
     Assertion test is a tuple, which are always True.

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -237,7 +237,7 @@ class IfTuple(Message):
     """
     Conditional test is a tuple, which are always True.
     """
-    message = 'if condition is always true, perhaps remove parentheses?'
+    message = '\'if tuple literal\' is always true, perhaps remove accidental comma?'
 
 
 class AssertTuple(Message):

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -1433,6 +1433,29 @@ class TestUnusedAssignment(TestCase):
         self.flakes("a = foo if True else 'oink'", m.UndefinedName)
         self.flakes("a = 'moo' if True else bar", m.UndefinedName)
 
+    def test_if_tuple(self):
+        """
+        Test C{if (foo,)} conditions.
+        """
+        self.flakes("""if (): pass""")
+        self.flakes("""
+        if (
+            True
+        ):
+            pass
+        """)
+        self.flakes("""
+        if (
+            True,
+        ):
+            pass
+        """, m.IfTuple)
+        self.flakes("""
+        x = 1 if (
+            True,
+        ) else 2
+        """, m.IfTuple)
+
     def test_withStatementNoNames(self):
         """
         No warnings are emitted for using inside or after a nameless C{with}


### PR DESCRIPTION
With the increasing prevalence of wrapping conditionals like:

``` python
    if (
        some_value != 'some_condition' and
        other_value is not 42
    )
```

and for wrapping other constructs with trailing commas, like:

``` python
    x = (
        some_value,
        other_value,
    )
```

it becomes quite easy to accidentally combine these into a conditional statement which is actually always true:

``` python
    if (
        some_value != 'some_condition' and
        other_value is not 42,
    )
```

This commit introduces a check for such constructs.