### PR TITLE
Fix quoted type annotations in unusual contexts

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -1563,6 +1563,15 @@ class Checker(object):
                 node.func.attr == 'format'
         ):
             self._handle_string_dot_format(node)
+
+        if (
+            _is_typing(node.func, 'cast', self.scopeStack) and
+            len(node.args) >= 1 and
+            isinstance(node.args[0], ast.Str)
+        ):
+            with self._enter_annotation():
+                self.handleNode(node.args[0], node)
+
         self.handleChildren(node)
 
     def _handle_percent_format(self, node):

--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -709,7 +709,7 @@ def _is_typing(node, typing_attr, scope_stack):
     This is used as part of working out whether we are within a type annotation
     context.
     """
-    return _is_typing_helper(node, typing_attr.__eq__, scope_stack)
+    return _is_typing_helper(node, lambda x: x == typing_attr, scope_stack)
 
 
 def _is_any_typing_member(node, scope_stack):

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -449,6 +449,23 @@ class TestTypeAnnotations(TestCase):
             return None
         """)
 
+    def test_quoted_type_cast(self):
+        self.flakes("""
+        from typing import cast, Optional
+
+        maybe_int = cast('Optional[int]', 42)
+        """)
+
+    def test_type_cast_literal_str_to_str(self):
+        # Checks that our handling of quoted type annotations in the first
+        # argument to `cast` doesn't cause issues when (only) the _second_
+        # argument is a literal str which looks a bit like a type annoation.
+        self.flakes("""
+        from typing import cast
+
+        a_string = cast(str, 'Optional[int]')
+        """)
+
     @skipIf(version_info < (3,), 'new in Python 3')
     def test_literal_type_typing(self):
         self.flakes("""

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -457,6 +457,14 @@ class TestTypeAnnotations(TestCase):
         MaybeQueue = Optional['Queue[str]']
         """)
 
+    def test_nested_partially_quoted_type_assignment(self):
+        self.flakes("""
+        from queue import Queue
+        from typing import Callable
+
+        Func = Callable[['Queue[str]'], None]
+        """)
+
     def test_quoted_type_cast(self):
         self.flakes("""
         from typing import cast, Optional

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -466,6 +466,13 @@ class TestTypeAnnotations(TestCase):
         a_string = cast(str, 'Optional[int]')
         """)
 
+    def test_quoted_type_cast_renamed_import(self):
+        self.flakes("""
+        from typing import cast as tsac, Optional as Maybe
+
+        maybe_int = tsac('Maybe[int]', 42)
+        """)
+
     @skipIf(version_info < (3,), 'new in Python 3')
     def test_literal_type_typing(self):
         self.flakes("""

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -449,6 +449,14 @@ class TestTypeAnnotations(TestCase):
             return None
         """)
 
+    def test_partially_quoted_type_assignment(self):
+        self.flakes("""
+        from queue import Queue
+        from typing import Optional
+
+        MaybeQueue = Optional['Queue[str]']
+        """)
+
     def test_quoted_type_cast(self):
         self.flakes("""
         from typing import cast, Optional


### PR DESCRIPTION
This aims to fix #510.

There is a case which this doesn't fix, which might need a slightly different approach -- that of a quoted annotation within a generic subscript for a user-defined type (which is inherently not part of the `typing` module).
For this reason I'm tempted to break out the subscript case from the `cast` case. Currently this would be fairly easy to do (the `cast` case is handled by the first two commits here, the latter commits relate to the subscript case).

Do we want to solve the general generics case now, or is this useful enough as it is?
~If we do want to solve this now, suggestions on how to approach it would be useful. I can see a couple of routes:~
- ~try to walk the parents of the type we find to see if this subscript should be read as an annotation (likely somewhat involved because I don't think `pyflakes` has anything approaching this at the moment?)~
- ~try to parse the subscript _both_ as an annotation and otherwise; this feels like it could result in some false results, but might be easier to get working. If this approach is preferred, do we have some examples of this sort of thing?~

Conclusion: we'll ignore this case for now.