### PR TITLE
Be more cautious when identifying typing Literal

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -1421,7 +1421,15 @@ class Checker(object):
         STARRED = NAMECONSTANT = NAMEDEXPR = handleChildren
 
     def SUBSCRIPT(self, node):
-        if _is_typing(node.value, 'Literal', self.scopeStack):
+        if (
+                (
+                    isinstance(node.value, ast.Name) and
+                    node.value.id == 'Literal'
+                ) or (
+                    isinstance(node.value, ast.Attribute) and
+                    node.value.attr == 'Literal'
+                )
+        ):
             orig, self._in_typing_literal = self._in_typing_literal, True
             try:
                 self.handleChildren(node)

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -468,6 +468,19 @@ class TestTypeAnnotations(TestCase):
         """)
 
     @skipIf(version_info < (3,), 'new in Python 3')
+    def test_literal_type_some_other_module(self):
+        """err on the side of false-negatives for types named Literal"""
+        self.flakes("""
+        from my_module import compat
+        from my_module.compat import Literal
+
+        def f(x: compat.Literal['some string']) -> None:
+            return None
+        def g(x: Literal['some string']) -> None:
+            return None
+        """)
+
+    @skipIf(version_info < (3,), 'new in Python 3')
     def test_literal_union_type_typing(self):
         self.flakes("""
         from typing import Literal


### PR DESCRIPTION
I feel that it's better to err on the side of false-negatives here than false-positives -- it's also especially unlikely that a typing-context subscript where the left hand side is "Literal" is anything other than `typing.Literal`

Originally brought up in https://github.com/PyCQA/pyflakes/pull/479#issuecomment-593150973