### PR TITLE
Fix quoted type annotations in typing.TypeVar contexts

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -1614,6 +1614,19 @@ class Checker(object):
             with self._enter_annotation():
                 self.handleNode(node.args[0], node)
 
+        elif _is_typing(node.func, 'TypeVar', self.scopeStack):
+            # TypeVar("T", "int", "str")
+            for arg in node.args[1:]:
+                if isinstance(arg, ast.Str):
+                    with self._enter_annotation():
+                        self.handleNode(arg, node)
+
+            # TypeVar("T", bound="str")
+            for keyword in node.keywords:
+                if keyword.arg == 'bound' and isinstance(keyword.value, ast.Str):
+                    with self._enter_annotation():
+                        self.handleNode(keyword.value, node)
+
         self.handleChildren(node)
 
     def _handle_percent_format(self, node):

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -489,6 +489,21 @@ class TestTypeAnnotations(TestCase):
         maybe_int = tsac('Maybe[int]', 42)
         """)
 
+    def test_quoted_TypeVar_constraints(self):
+        self.flakes("""
+        from typing import TypeVar, Optional
+
+        T = TypeVar('T', 'str', 'Optional[int]', bytes)
+        """)
+
+    def test_quoted_TypeVar_bound(self):
+        self.flakes("""
+        from typing import TypeVar, Optional, List
+
+        T = TypeVar('T', bound='Optional[int]')
+        S = TypeVar('S', int, bound='List[int]')
+        """)
+
     @skipIf(version_info < (3,), 'new in Python 3')
     def test_literal_type_typing(self):
         self.flakes("""


### PR DESCRIPTION
[`TypeVar`](https://docs.python.org/3/library/typing.html#typing.TypeVar) has such contexts in the positional arguments (for constraints) and in the `bound` keyword argument.