### PR TITLE
fix: don't return syntax error for Annotated's metadata

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -1272,7 +1272,7 @@ class Checker(object):
             yield
         finally:
             self._in_annotation = orig
-    
+
     @contextlib.contextmanager
     def _enter_typing_annotated(self):
         orig, self._in_typing_annotated = self._in_typing_annotated, True
@@ -1493,8 +1493,9 @@ class Checker(object):
             self.handleNode(node.value, node)
 
             if (
-                isinstance(node.slice, ast.Index) and
-                isinstance(node.slice.value, ast.Tuple)):
+                    isinstance(node.slice, ast.Index) and
+                    isinstance(node.slice.value, ast.Tuple)
+            ):
                 slice_children = list(iter_child_nodes(node.slice.value))
                 if slice_children:
                     self.handleNode(slice_children[0], node.slice)
@@ -1767,7 +1768,8 @@ class Checker(object):
         if (
                 self._in_annotation and
                 not self._in_typing_literal and
-                not self._in_typing_annotated):
+                not self._in_typing_annotated
+        ):
             fn = functools.partial(
                 self.handleStringAnnotation,
                 node.s,

--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -128,6 +128,13 @@ def _is_const_non_singleton(node):  # type: (ast.AST) -> bool
     return _is_constant(node) and not _is_singleton(node)
 
 
+def _is_name_or_attr(node, name):  # type: (ast.Ast, str) -> bool
+    return (
+        (isinstance(node, ast.Name) and node.id == name) or
+        (isinstance(node, ast.Attribute) and node.attr == name)
+    )
+
+
 # https://github.com/python/typed_ast/blob/1.4.0/ast27/Parser/tokenizer.c#L102-L104
 TYPE_COMMENT_RE = re.compile(r'^#\s*type:\s*')
 # https://github.com/python/typed_ast/blob/1.4.0/ast27/Parser/tokenizer.c#L1408-L1413
@@ -1497,45 +1504,37 @@ class Checker(object):
         STARRED = NAMECONSTANT = NAMEDEXPR = handleChildren
 
     def SUBSCRIPT(self, node):
-        if (
-                (
-                    isinstance(node.value, ast.Name) and
-                    node.value.id == 'Literal'
-                ) or (
-                    isinstance(node.value, ast.Attribute) and
-                    node.value.attr == 'Literal'
-                )
-        ):
+        if _is_name_or_attr(node.value, 'Literal'):
             orig, self._in_typing_literal = self._in_typing_literal, True
             try:
                 self.handleChildren(node)
             finally:
                 self._in_typing_literal = orig
-        elif (
-                (
-                    isinstance(node.value, ast.Name) and
-                    node.value.id == 'Annotated'
-                ) or (
-                    isinstance(node.value, ast.Attribute) and
-                    node.value.attr == 'Annotated'
-                )
-        ):
+        elif _is_name_or_attr(node.value, 'Annotated'):
             self.handleNode(node.value, node)
 
-            if (
+            # py39+
+            if isinstance(node.slice, ast.Tuple):
+                slice_tuple = node.slice
+            # <py39
+            elif (
                     isinstance(node.slice, ast.Index) and
                     isinstance(node.slice.value, ast.Tuple)
             ):
-                slice_children = list(iter_child_nodes(node.slice.value))
-                if slice_children:
-                    self.handleNode(slice_children[0], node.slice)
-                # Only the first argument of an Annotated type will always
-                # correspond to an actual type.
-                with self._enter_annotation(AnnotationState.NONE):
-                    for slice_child in slice_children[1:]:
-                        self.handleNode(slice_child, node)
+                slice_tuple = node.slice.value
             else:
+                slice_tuple = None
+
+            # not a multi-arg `Annotated`
+            if slice_tuple is None or len(slice_tuple.elts) < 2:
                 self.handleNode(node.slice, node)
+            else:
+                # the first argument is the type
+                self.handleNode(slice_tuple.elts[0], node)
+                # the rest of the arguments are not
+                with self._enter_annotation(AnnotationState.NONE):
+                    for arg in slice_tuple.elts[1:]:
+                        self.handleNode(arg, node)
 
             self.handleNode(node.ctx, node)
         else:

--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -1305,14 +1305,6 @@ class Checker(object):
         finally:
             self._in_annotation = orig
 
-    @contextlib.contextmanager
-    def _exit_annotation(self):
-        orig, self._in_annotation = self._in_annotation, AnnotationState.NONE
-        try:
-            yield
-        finally:
-            self._in_annotation = orig
-
     @property
     def _in_postponed_annotation(self):
         return (
@@ -1539,7 +1531,7 @@ class Checker(object):
                     self.handleNode(slice_children[0], node.slice)
                 # Only the first argument of an Annotated type will always
                 # correspond to an actual type.
-                with self._exit_annotation():
+                with self._enter_annotation(AnnotationState.NONE):
                     for slice_child in slice_children[1:]:
                         self.handleNode(slice_child, node)
             else:

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -506,7 +506,7 @@ class TestTypeAnnotations(TestCase):
         def f(x: Literal['some string']) -> None:
             return None
         """)
-    
+
     def test_forward_ref_valid(self):
         self.flakes("""
         from typing import Optional

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -507,6 +507,7 @@ class TestTypeAnnotations(TestCase):
             return None
         """)
 
+    @skipIf(version_info < (3,), 'new in Python 3')
     def test_forward_ref_valid(self):
         self.flakes("""
         from typing import Optional
@@ -515,6 +516,7 @@ class TestTypeAnnotations(TestCase):
             return None
         """)
 
+    @skipIf(version_info < (3,), 'new in Python 3')
     def test_forward_ref_missing(self):
         self.flakes("""
         from typing import Optional

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -508,24 +508,6 @@ class TestTypeAnnotations(TestCase):
         """)
 
     @skipIf(version_info < (3,), 'new in Python 3')
-    def test_forward_ref_valid(self):
-        self.flakes("""
-        from typing import Optional
-
-        def f(x: Optional['int']) -> None:
-            return None
-        """)
-
-    @skipIf(version_info < (3,), 'new in Python 3')
-    def test_forward_ref_missing(self):
-        self.flakes("""
-        from typing import Optional
-
-        def f(x: Optional['integer']) -> None:
-            return None
-        """, m.UndefinedName)
-
-    @skipIf(version_info < (3, 6), 'new in Python 3.6')
     def test_annotated_type_typing_missing_forward_type(self):
         self.flakes("""
         from typing import Annotated
@@ -534,7 +516,7 @@ class TestTypeAnnotations(TestCase):
             return None
         """, m.UndefinedName)
 
-    @skipIf(version_info < (3, 6), 'new in Python 3.6')
+    @skipIf(version_info < (3,), 'new in Python 3')
     def test_annotated_type_typing_missing_forward_type_multiple_args(self):
         self.flakes("""
         from typing import Annotated
@@ -543,7 +525,7 @@ class TestTypeAnnotations(TestCase):
             return None
         """, m.UndefinedName)
 
-    @skipIf(version_info < (3, 6), 'new in Python 3.6')
+    @skipIf(version_info < (3,), 'new in Python 3')
     def test_annotated_type_typing_with_string_args(self):
         self.flakes("""
         from typing import Annotated

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -506,6 +506,49 @@ class TestTypeAnnotations(TestCase):
         def f(x: Literal['some string']) -> None:
             return None
         """)
+    
+    def test_forward_ref_valid(self):
+        self.flakes("""
+        from typing import Optional
+
+        def f(x: Optional['int']) -> None:
+            return None
+        """)
+
+    def test_forward_ref_missing(self):
+        self.flakes("""
+        from typing import Optional
+
+        def f(x: Optional['integer']) -> None:
+            return None
+        """, m.UndefinedName)
+
+    @skipIf(version_info < (3, 6), 'new in Python 3.6')
+    def test_annotated_type_typing_missing_forward_type(self):
+        self.flakes("""
+        from typing import Annotated
+
+        def f(x: Annotated['integer']) -> None:
+            return None
+        """, m.UndefinedName)
+
+    @skipIf(version_info < (3, 6), 'new in Python 3.6')
+    def test_annotated_type_typing_missing_forward_type_multiple_args(self):
+        self.flakes("""
+        from typing import Annotated
+
+        def f(x: Annotated['integer', 1]) -> None:
+            return None
+        """, m.UndefinedName)
+
+    @skipIf(version_info < (3, 6), 'new in Python 3.6')
+    def test_annotated_type_typing_with_string_args(self):
+        self.flakes("""
+        from typing import Annotated
+
+        def f(x: Annotated[int, '> 0']) -> None:
+            return None
+        """)
 
     @skipIf(version_info < (3,), 'new in Python 3')
     def test_literal_type_some_other_module(self):

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -535,7 +535,7 @@ class TestTypeAnnotations(TestCase):
         """)
 
     @skipIf(version_info < (3,), 'new in Python 3')
-    def test_annotated_type_typing_with_string_args(self):
+    def test_annotated_type_typing_with_string_args_in_union(self):
         self.flakes("""
         from typing import Annotated, Union
 

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -535,6 +535,15 @@ class TestTypeAnnotations(TestCase):
         """)
 
     @skipIf(version_info < (3,), 'new in Python 3')
+    def test_annotated_type_typing_with_string_args(self):
+        self.flakes("""
+        from typing import Annotated, Union
+
+        def f(x: Union[Annotated['int', '>0'], 'integer']) -> None:
+            return None
+        """, m.UndefinedName)
+
+    @skipIf(version_info < (3,), 'new in Python 3')
     def test_literal_type_some_other_module(self):
         """err on the side of false-negatives for types named Literal"""
         self.flakes("""


### PR DESCRIPTION
PEP 593 https://www.python.org/dev/peps/pep-0593/ introduced the type Annotated, which allows to add metadata to types. By the definition only the first argument is required to be a proper type, all the other arguments are dependent on the consumer and can be other types or even literals.

This PR fixes #574.