### PR TITLE
Fix test_invalidEscape with recent PyPy3 versions, closes #584

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,18 +1,22 @@
 # To activate, change the Appveyor settings to use `.appveyor.yml`.
+environment:
+  PYPY_PY2_VERSION: 2.7
+  PYPY_PY3_VERSION: 3.6
+  PYPY_VERSION: 7.3.2
 install:
   - python -m pip install --upgrade tox virtualenv
 
-  - ps: (New-Object Net.WebClient).DownloadFile('https://downloads.python.org/pypy/pypy2.7-v7.1.1-win32.zip', "$env:appveyor_build_folder\pypy2.7-v7.1.1-win32.zip")
-  - ps: 7z x pypy2.7-v7.1.1-win32.zip | Out-Null
-  - move pypy2.7-v7.1.1-win32 C:\
-  - 'SET PATH=C:\pypy2.7-v7.1.1-win32\;%PATH%'
+  - ps: (New-Object Net.WebClient).DownloadFile("https://downloads.python.org/pypy/pypy${env:PYPY_PY2_VERSION}-v${env:PYPY_VERSION}-win32.zip", "$env:appveyor_build_folder\pypy${env:PYPY_PY2_VERSION}-v${env:PYPY_VERSION}-win32.zip")
+  - ps: 7z x pypy${env:PYPY_PY2_VERSION}-v${env:PYPY_VERSION}-win32.zip | Out-Null
+  - move pypy%PYPY_PY2_VERSION%-v%PYPY_VERSION%-win32 C:\
+  - 'SET PATH=C:\pypy%PYPY_PY2_VERSION%-v%PYPY_VERSION%-win32\;%PATH%'
 
-  - ps: (New-Object Net.WebClient).DownloadFile('https://downloads.python.org/pypy/pypy3.6-v7.1.1-win32.zip', "$env:appveyor_build_folder\pypy3.6-v7.1.1-win32.zip")
-  - ps: 7z x pypy3.6-v7.1.1-win32.zip | Out-Null
-  - move pypy3.6-v7.1.1-win32 C:\
-  - 'SET PATH=C:\pypy3.6-v7.1.1-win32\;%PATH%'
+  - ps: (New-Object Net.WebClient).DownloadFile("https://downloads.python.org/pypy/pypy${env:PYPY_PY3_VERSION}-v${env:PYPY_VERSION}-win32.zip", "$env:appveyor_build_folder\pypy${env:PYPY_PY3_VERSION}-v${env:PYPY_VERSION}-win32.zip")
+  - ps: 7z x pypy${env:PYPY_PY3_VERSION}-v${env:PYPY_VERSION}-win32.zip | Out-Null
+  - move pypy%PYPY_PY3_VERSION%-v%PYPY_VERSION%-win32 C:\
+  - 'SET PATH=C:\pypy%PYPY_PY3_VERSION%-v%PYPY_VERSION%-win32\;%PATH%'
 
 build: off
 
 test_script:
-  - python -m tox
+  - python -m tox --skip-missing-interpreters=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ matrix:
     - python: 3.4
     - python: 3.5
     - python: 3.6
-    - python: pypy
-    - python: pypy3
+    - python: pypy2.7-7.3.1
+    - python: pypy3.6-7.3.1
     - python: 3.7
       dist: xenial
     - python: 3.8

--- a/pyflakes/test/test_api.py
+++ b/pyflakes/test/test_api.py
@@ -515,7 +515,7 @@ def foo(bar=baz, bax):
 """
         with self.makeTempFile(source) as sourcePath:
             if ERROR_HAS_LAST_LINE:
-                if PYPY and sys.version_info >= (3,):
+                if PYPY:
                     column = 7
                 elif sys.version_info >= (3, 8):
                     column = 9
@@ -543,7 +543,7 @@ foo(bar=baz, bax)
 """
         with self.makeTempFile(source) as sourcePath:
             if ERROR_HAS_LAST_LINE:
-                if PYPY and sys.version_info >= (3,):
+                if PYPY:
                     column = 12
                 elif sys.version_info >= (3, 8):
                     column = 14
@@ -578,7 +578,7 @@ foo(bar=baz, bax)
             else:
                 position_end = 1
                 if PYPY:
-                    column = 6
+                    column = 5
                 else:
                     column = 7
                     # Column has been "fixed" since 3.2.4 and 3.3.1
@@ -717,13 +717,6 @@ class IntegrationTests(TestCase):
     """
     Tests of the pyflakes script that actually spawn the script.
     """
-
-    # https://bitbucket.org/pypy/pypy/issues/3069/pypy36-on-windows-incorrect-line-separator
-    if PYPY and sys.version_info >= (3,) and WIN:
-        LINESEP = '\n'
-    else:
-        LINESEP = os.linesep
-
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
         self.tempfilepath = os.path.join(self.tempdir, 'temp')
@@ -784,7 +777,7 @@ class IntegrationTests(TestCase):
             fd.write("import contraband\n".encode('ascii'))
         d = self.runPyflakes([self.tempfilepath])
         expected = UnusedImport(self.tempfilepath, Node(1), 'contraband')
-        self.assertEqual(d, ("%s%s" % (expected, self.LINESEP), '', 1))
+        self.assertEqual(d, ("%s%s" % (expected, os.linesep), '', 1))
 
     def test_errors_io(self):
         """
@@ -794,7 +787,7 @@ class IntegrationTests(TestCase):
         """
         d = self.runPyflakes([self.tempfilepath])
         error_msg = '%s: No such file or directory%s' % (self.tempfilepath,
-                                                         self.LINESEP)
+                                                         os.linesep)
         self.assertEqual(d, ('', error_msg, 1))
 
     def test_errors_syntax(self):
@@ -807,7 +800,7 @@ class IntegrationTests(TestCase):
             fd.write("import".encode('ascii'))
         d = self.runPyflakes([self.tempfilepath])
         error_msg = '{0}:1:{2}: invalid syntax{1}import{1}     {3}^{1}'.format(
-            self.tempfilepath, self.LINESEP, 6 if PYPY else 7, '' if PYPY else ' ')
+            self.tempfilepath, os.linesep, 6 if PYPY else 7, '' if PYPY else ' ')
         self.assertEqual(d, ('', error_msg, 1))
 
     def test_readFromStdin(self):
@@ -816,15 +809,13 @@ class IntegrationTests(TestCase):
         """
         d = self.runPyflakes([], stdin='import contraband')
         expected = UnusedImport('<stdin>', Node(1), 'contraband')
-        self.assertEqual(d, ("%s%s" % (expected, self.LINESEP), '', 1))
+        self.assertEqual(d, ("%s%s" % (expected, os.linesep), '', 1))
 
 
 class TestMain(IntegrationTests):
     """
     Tests of the pyflakes main function.
     """
-    LINESEP = os.linesep
-
     def runPyflakes(self, paths, stdin=None):
         try:
             with SysStreamCapturing(stdin) as capture:

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
 deps = flake8==3.6.0
 setenv = PYFLAKES_ERROR_UNKNOWN=1
 commands =
+    python --version --version
     python -m unittest discover pyflakes
     flake8 pyflakes setup.py
 


### PR DESCRIPTION
@asottile This was surprisingly easy 🙂

I'm not sure if we need to account for older PyPy versions, please let me know.