### PR TITLE
Recognize __qualname__ when used in class scope

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -669,6 +669,10 @@ class DummyNode(object):
         self.col_offset = col_offset
 
 
+class DetectClassScopedMagic:
+    names = dir()
+
+
 # Globally defined names which are not attributes of the builtins module, or
 # are only present on some platforms.
 _MAGIC_GLOBALS = ['__file__', '__builtins__', 'WindowsError']
@@ -1231,7 +1235,7 @@ class Checker(object):
             # the special name __path__ is valid only in packages
             return
 
-        if name == '__module__' and isinstance(self.scope, ClassScope):
+        if name in DetectClassScopedMagic.names and isinstance(self.scope, ClassScope):
             return
 
         # protected with a NameError handler?

--- a/pyflakes/test/test_undefined_names.py
+++ b/pyflakes/test/test_undefined_names.py
@@ -279,6 +279,23 @@ class Test(TestCase):
                 __module__
         ''', m.UndefinedName)
 
+    @skipIf(version_info < (3, 3), "Python >= 3.3 only")
+    def test_magicQualnameInClassScope(self):
+        """
+        Use of the C{__qualname__} magic builtin should not emit an undefined
+        name warning if used in class scope.
+        """
+        self.flakes('__qualname__', m.UndefinedName)
+        self.flakes('''
+        class Foo:
+            __qualname__
+        ''')
+        self.flakes('''
+        class Foo:
+            def bar(self):
+                __qualname__
+        ''', m.UndefinedName)
+
     def test_globalImportStar(self):
         """Can't find undefined names with import *."""
         self.flakes('from fu import *; bar',


### PR DESCRIPTION
`pyflakes` doesn't recognize [`__qualname__`](https://docs.python.org/3/glossary.html#term-qualified-name).

Reproducer:
```
$ echo -e "class Foo:\n    __qualname__" | python3
$ pyflakes --version
2.2.0 Python 3.8.6 on Linux
$ echo -e "class Foo:\n    __qualname__" | pyflakes 
<stdin>:2:5 undefined name '__qualname__'
```

Initially reported [here](https://gitlab.com/pycqa/flake8/-/issues/227), relates #259.