### PR TITLE
Test PyPy on GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,6 @@ jobs:
           - { os: "windows-latest" , python-version: "2.7" }
           - { os: "windows-latest" , python-version: "3.5" }
           - { os: "windows-latest" , python-version: "3.9" }
-        exclude:
-          # Currently fails with PyPy 7.3.2, pending 7.3.3+ on GHA:
-          # https://github.com/actions/setup-python/issues/163
           - { os: "windows-latest" , python-version: "pypy2" }
           - { os: "windows-latest" , python-version: "pypy3" }
 


### PR DESCRIPTION
GitHub Actions now has the newest PyPy 7.3.3, so we can now test it on Windows.

Re: https://github.com/actions/setup-python/issues/163#issuecomment-739907048