### PR TITLE
deterministic ordering for errors in __all__

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -992,7 +992,10 @@ class Checker(object):
 
             if all_binding:
                 all_names = set(all_binding.names)
-                undefined = all_names.difference(scope)
+                undefined = [
+                    name for name in all_binding.names
+                    if name not in scope
+                ]
             else:
                 all_names = undefined = []
 


### PR DESCRIPTION
Resolves #603

I couldn't figure out a way to test this that wasn't flakey and without writing a bunch of test infra to look at the actual messages (since they're all the same type)

Here's a demo of the fix however:

```console
$ python3 -m pyflakes t.py
t.py:1:1 undefined name 'a' in __all__
t.py:1:1 undefined name 'b' in __all__
t.py:1:1 undefined name 'c' in __all__
t.py:1:1 undefined name 'd' in __all__
$ python3 -m pyflakes t.py
t.py:1:1 undefined name 'a' in __all__
t.py:1:1 undefined name 'b' in __all__
t.py:1:1 undefined name 'c' in __all__
t.py:1:1 undefined name 'd' in __all__
$ python3 -m pyflakes t.py
t.py:1:1 undefined name 'a' in __all__
t.py:1:1 undefined name 'b' in __all__
t.py:1:1 undefined name 'c' in __all__
t.py:1:1 undefined name 'd' in __all__
$ python3 -m pyflakes t.py
t.py:1:1 undefined name 'a' in __all__
t.py:1:1 undefined name 'b' in __all__
t.py:1:1 undefined name 'c' in __all__
t.py:1:1 undefined name 'd' in __all__
$ python3 -m pyflakes t.py
t.py:1:1 undefined name 'a' in __all__
t.py:1:1 undefined name 'b' in __all__
t.py:1:1 undefined name 'c' in __all__
t.py:1:1 undefined name 'd' in __all__
```