### PR TITLE
allow turning on run tracing from the command line

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -878,7 +878,8 @@ class Checker(object):
     #       eventually make this a required positional argument.  For now it
     #       is defaulted to `()` for api compatibility.
     def __init__(self, tree, filename='(none)', builtins=None,
-                 withDoctest='PYFLAKES_DOCTEST' in os.environ, file_tokens=()):
+                 withDoctest='PYFLAKES_DOCTEST' in os.environ, file_tokens=(),
+                 trace=False):
         self._nodeHandlers = {}
         self._deferredFunctions = []
         self._deferredAssignments = []
@@ -888,6 +889,7 @@ class Checker(object):
         if builtins:
             self.builtIns = self.builtIns.union(builtins)
         self.withDoctest = withDoctest
+        self.traceTree = trace
         try:
             self.scopeStack = [Checker._ast_node_scope[type(tree)]()]
         except KeyError:


### PR DESCRIPTION
This along with some additional tracing output was used to help with #622.

In the additional changes I added the tracing to also print out the stack information when popping the stack. Eventually I added some more context to which stack was being printed and while I shimmed the information in via `def popStack(self, node=None)` to optionally provide node information for name and file/line context. I was wondering if it would be OK if I were to add a node to each stack created instead of trying to "merge" them via the checker.

For the stack information I printed out if the name was used and if it was available for runtime usage. An example of this would be the following:

```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from module import Type

    class A:
        def a(x) -> Type:
            pass
else:
    class A:
        def a(x):
            pass

def b(x) -> Type:
    from module import Type

    assert isinstance(x, Type)
    return x

class C:
    def c(x) -> Type:
        from module import Type

        assert isinstance(x, Type)
        return x
```

```
ImportFrom
end ImportFrom
If
  Name
  end Name
  ImportFrom
  end ImportFrom
  ClassDef
    FunctionDef
      Name
      end Name
    end FunctionDef
    ClassScope(A):<stdin>:6:5
      a:
        used: False
        runtime: False
  end ClassDef
  ClassDef
    FunctionDef
    end FunctionDef
    ClassScope(A):<stdin>:10:5
      a:
        used: False
        runtime: True
  end ClassDef
end If
FunctionDef
  Name
  end Name
end FunctionDef
ClassDef
  FunctionDef
    Name
    end Name
  end FunctionDef
  ClassScope(C):<stdin>:20:1
    c:
      used: False
      runtime: True
end ClassDef
arguments
  arg
  end arg
end arguments
Pass
end Pass
FunctionScope(a):<stdin>:7:9
  x:
    used: False
    runtime: True
arguments
  arg
  end arg
end arguments
Pass
end Pass
FunctionScope(a):<stdin>:11:9
  x:
    used: False
    runtime: True
arguments
  arg
  end arg
end arguments
ImportFrom
end ImportFrom
Assert
  Call
    Name
    end Name
    Name
    end Name
    Name
    end Name
  end Call
end Assert
Return
  Name
  end Name
end Return
FunctionScope(b):<stdin>:14:1
  Type:
    used: True
    runtime: True
  x:
    used: True
    runtime: True
arguments
  arg
  end arg
end arguments
ImportFrom
end ImportFrom
Assert
  Call
    Name
    end Name
    Name
    end Name
    Name
    end Name
  end Call
end Assert
Return
  Name
  end Name
end Return
FunctionScope(c):<stdin>:21:5
  Type:
    used: True
    runtime: True
  x:
    used: True
    runtime: True
ModuleScope
  A:
    used: False
    runtime: True
  C:
    used: False
    runtime: True
  TYPE_CHECKING:
    used: True
    runtime: True
  Type:
    used: True
    runtime: False
  b:
    used: False
    runtime: True
  isinstance:
    used: True
    runtime: True
```