### PR TITLE
allow passing tox positional arguments to unittest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps = flake8==3.6.0
 setenv = PYFLAKES_ERROR_UNKNOWN=1
 commands =
     python --version --version
-    python -m unittest discover pyflakes
+    python -m unittest discover pyflakes {posargs}
     flake8 pyflakes setup.py
 
 [flake8]


### PR DESCRIPTION
This allows `tox -e py27 -- -k <test name>`.