### PR TITLE
Detect typing module attributes with 'import typing as <name>'

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -717,6 +717,16 @@ def _is_typing_helper(node, is_name_match_fn, scope_stack):
 
         return False
 
+    def _module_scope_is_typing(name):
+        for scope in reversed(scope_stack):
+            if name in scope:
+                return (
+                    isinstance(scope[name], Importation) and
+                    scope[name].fullName in TYPING_MODULES
+                )
+
+        return False
+
     return (
         (
             isinstance(node, ast.Name) and
@@ -724,7 +734,7 @@ def _is_typing_helper(node, is_name_match_fn, scope_stack):
         ) or (
             isinstance(node, ast.Attribute) and
             isinstance(node.value, ast.Name) and
-            node.value.id in TYPING_MODULES and
+            _module_scope_is_typing(node.value.id) and
             is_name_match_fn(node.attr)
         )
     )

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -127,14 +127,14 @@ class TestTypeAnnotations(TestCase):
         import typing as t
 
         @t.overload
-        async def f(s):  # type: (None) -> None
+        def f(s):  # type: (None) -> None
             pass
 
         @t.overload
-        async def f(s):  # type: (int) -> int
+        def f(s):  # type: (int) -> int
             pass
 
-        async def f(s):
+        def f(s):
             return s
         """)
 

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -121,6 +121,23 @@ class TestTypeAnnotations(TestCase):
             def f(self, x): return x
         """)
 
+    def test_aliased_import(self):
+        """Detect when typing is imported as another name"""
+        self.flakes("""
+        import typing as t
+
+        @t.overload
+        async def f(s):  # type: (None) -> None
+            pass
+
+        @t.overload
+        async def f(s):  # type: (int) -> int
+            pass
+
+        async def f(s):
+            return s
+        """)
+
     def test_not_a_typing_overload(self):
         """regression test for @typing.overload detection bug in 2.1.0"""
         self.flakes("""


### PR DESCRIPTION
Fixes #561

See https://github.com/pallets/click/pull/1896#discussion_r632645323 for use case.