### PR TITLE
Add project URLs to setup.py metadata for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,12 @@ setup(
     author="A lot of people",
     author_email="code-quality@python.org",
     url="https://github.com/PyCQA/pyflakes",
+    project_urls={
+        "Source": "https://github.com/PyCQA/pyflakes",
+        "Changelog": "https://github.com/PyCQA/pyflakes/blob/master/NEWS.rst",
+        "Bug Tracker": "https://github.com/PyCQA/pyflakes/issues",
+        "Mailing List": "https://mail.python.org/mailman/listinfo/code-quality",
+    },
     packages=["pyflakes", "pyflakes.scripts", "pyflakes.test"],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[


### PR DESCRIPTION
This will make it easier to find e.g. the changelog or mailing-list by adding links to the left bar on [the pypi.org page](https://pypi.org/project/pyflakes/):

![PyPI screenshot](https://user-images.githubusercontent.com/426784/135724039-3c2b01db-f4c9-4fee-b06d-c33c71fa197d.png)