### PR TITLE
add tests for python3.11-specific syntax

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-beta - 3.11.999", "pypy-3.7"]
         os: [ubuntu-latest]
         # Include minimum py3 + maximum py3 + pypy3 on Windows
         include:

--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -2331,7 +2331,7 @@ class Checker(object):
         # Process the other nodes: "except:", "else:", "finally:"
         self.handleChildren(node, omit='body')
 
-    TRYEXCEPT = TRY
+    TRYEXCEPT = TRYSTAR = TRY
 
     def EXCEPTHANDLER(self, node):
         if PY2 or node.name is None:

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -1668,6 +1668,15 @@ class TestUnusedAssignment(TestCase):
         except Exception as e: pass
         ''', m.UnusedVariable)
 
+    @skipIf(version_info < (3, 11), 'new in Python 3.11')
+    def test_exception_unused_in_except_star(self):
+        self.flakes('''
+            try:
+                pass
+            except* OSError as e:
+                pass
+        ''', m.UnusedVariable)
+
     def test_exceptionUnusedInExceptInFunction(self):
         self.flakes('''
         def download_review():

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -801,3 +801,18 @@ class TestTypeAnnotations(TestCase):
             class Y(NamedTuple):
                 y: NamedTuple("v", [("vv", int)])
         """)
+
+    @skipIf(version_info < (3, 11), 'new in Python 3.11')
+    def test_variadic_generics(self):
+        self.flakes("""
+            from typing import Generic
+            from typing import TypeVarTuple
+
+            Ts = TypeVarTuple('Ts')
+
+            class Shape(Generic[*Ts]): pass
+
+            def f(*args: *Ts) -> None: ...
+
+            def g(x: Shape[*Ts]) -> Shape[*Ts]: ...
+        """)


### PR DESCRIPTION
fortunately we don't really need to make a new release for this thanks to the work I did in #490

the only behaviour this "fixes" is this pattern which I highly doubt anyone would use in reality:

```python
try:
    undefined_name
except* NameError:
    pass
```