### PR TITLE
Create pre-commit-hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: pyflakes
+  name: pyflakes
+  entry: pyflakes
+  language: python
+  types: [python]
+  require_serial: true


### PR DESCRIPTION
Hi!

I created the file `.pre-commit-hooks.yaml` as an edited copy from [PyCQA/pylint](https://github.com/PyCQA/pylint/blob/main/.pre-commit-hooks.yaml).

A user can currently use this with their `.pre-commit-config.yaml`
```yaml
repos:
  - repo: https://github.com/nbiederbeck/pyflakes
    rev: 436000a
    hooks:
      - id: pyflakes
```
but would later of course change to this repo.