### PR TITLE
fix syntax error reporting from stdin (#357)

### DIFF
--- a/pyflakes/api.py
+++ b/pyflakes/api.py
@@ -55,14 +55,7 @@ def check(codeString, filename, reporter=None):
                             text = None
             offset -= 1
 
-        # If there's an encoding problem with the file, the text is None.
-        if text is None:
-            # Avoid using msg, since for the only known case, it contains a
-            # bogus message that claims the encoding the file declared was
-            # unknown.
-            reporter.unexpectedError(filename, 'problem decoding source')
-        else:
-            reporter.syntaxError(filename, msg, lineno, offset, text)
+        reporter.syntaxError(filename, msg, lineno, offset, text)
         return 1
     except Exception:
         reporter.unexpectedError(filename, 'problem decoding source')


### PR DESCRIPTION
In b73a3d12, there was an assumption that text is None only if there was an
encoding error with the file. However this was the case for all pythons before
3.9 when reading code from stdin.

This takes care to correctly report as much context as possible, so errors
aren't silently dropped with the unhelpful "problem decoding source" message.