### PR TITLE
Add __debuggerskip__ as special local

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -567,7 +567,7 @@ class FunctionScope(Scope):
     """
     usesLocals = False
     alwaysUsed = {'__tracebackhide__', '__traceback_info__',
-                  '__traceback_supplement__'}
+                  '__traceback_supplement__', '__debuggerskip__'}
 
     def __init__(self):
         super().__init__()

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -1373,6 +1373,16 @@ class TestUnusedAssignment(TestCase):
                 __tracebackhide__ = True
         """)
 
+    def test_debuggerskipSpecialVariable(self):
+        """
+        Do not warn about unused local variable __debuggerskip__, which is
+        a special variable for IPython.
+        """
+        self.flakes("""
+            def helper():
+                __debuggerskip__ = True
+        """)
+
     def test_ifexp(self):
         """
         Test C{foo if bar else baz} statements.


### PR DESCRIPTION
__debuggerskip__ is a special variable used by IPython, similar to __tracebackhide__.