### PR TITLE
produce an error when a definition shadows an unused assignment

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -274,6 +274,11 @@ class Definition(Binding):
     """
     A binding that defines a function or a class.
     """
+    def redefines(self, other):
+        return (
+            super().redefines(other) or
+            (isinstance(other, Assignment) and self.name == other.name)
+        )
 
 
 class Builtin(Definition):

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -118,6 +118,12 @@ class Test(TestCase):
         def a(): pass
         ''', m.RedefinedWhileUnused)
 
+    def test_redefined_function_shadows_variable(self):
+        self.flakes('''
+        x = 1
+        def x(): pass
+        ''', m.RedefinedWhileUnused)
+
     def test_redefinedUnderscoreFunction(self):
         """
         Test that shadowing a function definition named with underscore doesn't


### PR DESCRIPTION
resolves #760