### PR TITLE
Add changelog URL to package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,9 @@ setup(
     url="https://github.com/PyCQA/pyflakes",
     packages=["pyflakes", "pyflakes.scripts", "pyflakes.test"],
     python_requires='>=3.8',
+    project_urls={
+        "Changelog": "https://github.com/PyCQA/pyflakes/blob/main/NEWS.rst",
+    },
     classifiers=[
         "Development Status :: 6 - Mature",
         "Environment :: Console",


### PR DESCRIPTION
These links will be visible on the package's PyPI page:

> ![image](https://github.com/PyCQA/pyflakes/assets/137616/f4316382-a78c-4176-9dda-530e20d2a65e)

And also tools like Renovate bot use this to provide direct access to the changelog for a dependency update.
