### PR TITLE
Fix supported Python versions in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ parsing the source file, not importing it, so it is safe to use on
 modules with side effects.  It's also much faster.
 
 It is `available on PyPI <https://pypi.org/project/pyflakes/>`_
-and it supports all active versions of Python: 3.6+.
+and it supports all active versions of Python: 3.8+.
 
 
 


### PR DESCRIPTION
The README has been using an outdated Python version range.