### PR TITLE
Add pre-commit hook definition

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+-   id: pyflakes
+    name: pyflakes
+    description: '`pyflakes` checks Python source code for errors.'
+    entry: pyflakes
+    language: python
+    types: [python]
+    require_serial: true


### PR DESCRIPTION
I wanted to use pyflakes specifically (not flake8) as a pre-commit hook. I can do this from my own fork, but if you'd like to include this file in the official repo, that would be appreciated. Thanks! :slightly_smiling_face: 