### PR TITLE
add warning for unused global / nonlocal names

### DIFF
--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -168,6 +168,15 @@ class UnusedAnnotation(Message):
         self.message_args = (names,)
 
 
+class UnusedIndirectAssignment(Message):
+    """A `global` or `nonlocal` statement where the name is never reassigned"""
+    message = '`%s %s` is unused: name is never assigned in scope'
+
+    def __init__(self, filename, loc, name):
+        Message.__init__(self, filename, loc)
+        self.message_args = (type(loc).__name__.lower(), name)
+
+
 class ReturnOutsideFunction(Message):
     """
     Indicates a return statement outside of a function/method.

--- a/pyflakes/test/test_imports.py
+++ b/pyflakes/test/test_imports.py
@@ -654,7 +654,7 @@ class Test(TestCase):
         self.flakes('''
         import fu
         def f(): global fu
-        ''', m.UnusedImport)
+        ''', m.UnusedImport, m.UnusedIndirectAssignment)
 
     def test_usedAndGlobal(self):
         """
@@ -665,7 +665,7 @@ class Test(TestCase):
             import foo
             def f(): global foo
             def g(): foo.is_used()
-        ''')
+        ''', m.UnusedIndirectAssignment)
 
     def test_assignedToGlobal(self):
         """

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -1085,7 +1085,41 @@ class Test(TestCase):
         self.flakes('''
         def f(): global foo
         def g(): foo = 'anything'; foo.is_used()
-        ''')
+        ''', m.UnusedIndirectAssignment)
+
+    def test_unused_global_statement(self):
+        self.flakes('''
+        g = 0
+        def f1():
+            global g
+            g = 1
+        def f2():
+            global g  # this is unused!
+            return g
+        ''', m.UnusedIndirectAssignment)
+
+    def test_unused_nonlocal_statement(self):
+        self.flakes('''
+        def f():
+            x = 1
+            def set_x():
+                nonlocal x
+                x = 2
+            def get_x():
+                nonlocal x
+                return x
+            set_x()
+            return get_x()
+        ''', m.UnusedIndirectAssignment)
+
+    def test_unused_global_statement_not_marked_as_used_by_nested_scope(self):
+        self.flakes('''
+        g = 0
+        def f():
+            global g
+            def f2():
+                g = 2
+        ''', m.UnusedIndirectAssignment, m.UnusedVariable)
 
     def test_function_arguments(self):
         """

--- a/pyflakes/test/test_undefined_names.py
+++ b/pyflakes/test/test_undefined_names.py
@@ -327,7 +327,7 @@ class Test(TestCase):
 
         def f2():
             global m
-        ''', m.UndefinedName)
+        ''', m.UndefinedName, m.UnusedIndirectAssignment)
 
     @skip("todo")
     def test_unused_global(self):
@@ -462,7 +462,7 @@ class Test(TestCase):
                     a
                     a = 2
                     return a
-        ''', m.UndefinedLocal)
+        ''', m.UndefinedLocal, m.UnusedIndirectAssignment)
 
     def test_intermediateClassScopeIgnored(self):
         """


### PR DESCRIPTION
some example output from a work codebase:

```console
$ flake8  src/ tests/
src/sentry/backup/imports.py:397:9: F999 `nonlocal deferred_org_auth_tokens` is unused: name is never assigned in scope
src/sentry/backup/imports.py:397:9: F999 `nonlocal import_write_context` is unused: name is never assigned in scope
src/sentry/llm/usecases/__init__.py:29:5: F999 `global llm_provider_backends` is unused: name is never assigned in scope
src/sentry/runner/commands/workstations.py:191:13: F999 `nonlocal proc` is unused: name is never assigned in scope
src/sentry/runner/commands/workstations.py:191:13: F999 `nonlocal silence_stderr` is unused: name is never assigned in scope
src/sentry/taskworker/worker.py:95:9: F999 `nonlocal current_activation` is unused: name is never assigned in scope
src/sentry/taskworker/worker.py:95:9: F999 `nonlocal processed_tasks` is unused: name is never assigned in scope
src/sentry/utils/mockdata/core.py:941:17: F999 `nonlocal timestamp` is unused: name is never assigned in scope
src/sentry/utils/mockdata/core.py:1188:17: F999 `nonlocal timestamp` is unused: name is never assigned in scope
src/sentry/utils/mockdata/core.py:1189:17: F999 `nonlocal duration` is unused: name is never assigned in scope
src/social_auth/backends/__init__.py:731:5: F999 `global BACKENDSCACHE` is unused: name is never assigned in scope
tests/sentry/backup/test_rpc.py:57:13: F999 `nonlocal option_count` is unused: name is never assigned in scope
tests/sentry/backup/test_rpc.py:57:13: F999 `nonlocal import_chunk_count` is unused: name is never assigned in scope
tests/sentry/backup/test_rpc.py:57:13: F999 `nonlocal import_uuid` is unused: name is never assigned in scope
tests/sentry/backup/test_rpc.py:134:13: F999 `nonlocal control_option_count` is unused: name is never assigned in scope
tests/sentry/backup/test_rpc.py:134:13: F999 `nonlocal import_chunk_count` is unused: name is never assigned in scope
tests/sentry/backup/test_rpc.py:134:13: F999 `nonlocal import_uuid` is unused: name is never assigned in scope
tests/sentry/hybridcloud/rpc/test_caching.py:129:9: F999 `nonlocal true_value` is unused: name is never assigned in scope

```