### PR TITLE
Allow an assignment expression to redefine an annotation

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -1008,8 +1008,12 @@ class Checker:
                     for scope in reversed(self.scopeStack)
                     if not isinstance(scope, GeneratorScope)
                 )
-                # it may be a re-assignment to an already existing name
-                scope.setdefault(value.name, value)
+                if value.name in scope and isinstance(scope[value.name], Annotation):
+                    # re-assignment to name that was previously only an annotation
+                    scope[value.name] = value
+                else:
+                    # it may be a re-assignment to an already existing name
+                    scope.setdefault(value.name, value)
             else:
                 self.scope[value.name] = value
 

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -1744,6 +1744,13 @@ class TestUnusedAssignment(TestCase):
         print(x)
         ''')
 
+    def test_assign_expr_after_annotation(self):
+        self.flakes("""
+        a: int
+        print(a := 3)
+        print(a)
+        """)
+
     def test_assign_expr_generator_scope(self):
         """Test assignment expressions in generator expressions."""
         self.flakes('''


### PR DESCRIPTION
This PR fixes the issue I reported, #830

It effectively reverts part of [this commit](https://github.com/PyCQA/pyflakes/commit/b1f8362e45aab6e5ba0b49b282b5be9c05467c50) so that annotations in scope are allowed to be re-assigned.