### PR TITLE
Fix F821 false positive for aliased Annotated and Literal imports

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -1372,10 +1372,16 @@ class Checker:
         NAMEDEXPR = handleChildren
 
     def SUBSCRIPT(self, node):
-        if _is_name_or_attr(node.value, 'Literal'):
+        if (
+            _is_typing(node.value, 'Literal', self.scopeStack)
+            or _is_name_or_attr(node.value, 'Literal')
+        ):
             with self._enter_annotation(AnnotationState.NONE):
                 self.handleChildren(node)
-        elif _is_name_or_attr(node.value, 'Annotated'):
+        elif (
+            _is_typing(node.value, 'Annotated', self.scopeStack)
+            or _is_name_or_attr(node.value, 'Annotated')
+        ):
             self.handleNode(node.value, node)
 
             # py39+

--- a/pyflakes/test/test_type_annotations.py
+++ b/pyflakes/test/test_type_annotations.py
@@ -598,6 +598,32 @@ class TestTypeAnnotations(TestCase):
             return None
         """)
 
+    def test_annotated_type_typing_alias(self):
+        """Annotated imported under an alias should not produce F821."""
+        self.flakes("""
+        from typing_extensions import Annotated as WithSchema
+
+        def f(x: WithSchema[int, 'hello']) -> None:
+            return None
+        """)
+
+    def test_annotated_type_typing_alias_forward_type(self):
+        self.flakes("""
+        from typing import Annotated as Ann
+
+        def f(x: Ann['integer', 1]) -> None:
+            return None
+        """, m.UndefinedName)
+
+    def test_literal_type_typing_alias(self):
+        """Literal imported under an alias should not produce F821."""
+        self.flakes("""
+        from typing import Literal as Lit
+
+        def f(x: Lit['some string']) -> None:
+            return None
+        """)
+
     def test_deferred_twice_annotation(self):
         self.flakes("""
             from queue import Queue


### PR DESCRIPTION
## Summary

- Use `_is_typing()` (scope-aware import resolution) alongside `_is_name_or_attr()` (literal name check) in the `SUBSCRIPT` handler for `Literal` and `Annotated`
- `_is_typing()` resolves import aliases through the scope stack, so `from typing import Annotated as WithSchema` is correctly recognized as a typing member
- The `_is_name_or_attr()` fallback is preserved to maintain the existing false-negative-safe behavior for non-typing modules that export names called `Literal` or `Annotated`
- Added three regression tests for aliased imports

## Reproducer

```python
from typing_extensions import Annotated as WithSchema

def f(x: WithSchema[int, "hello"]) -> None:
    return
```

**Before:** `F821 undefined name 'hello'`
**After:** No warning (metadata arguments in `Annotated` are correctly treated as non-type expressions)

The same fix applies to `Literal` aliases.

Closes #789