### PR TITLE
Avoid class methods redefining outer imports

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -993,7 +993,11 @@ class Checker:
                 if isinstance(scope, (ClassScope, FunctionScope)):
                     scope.indirect_assignments.pop(value.name, None)
 
-            elif isinstance(existing, Importation) and value.redefines(existing):
+            elif (
+                    isinstance(existing, Importation) and
+                    value.redefines(existing) and
+                    not isinstance(self.scope, ClassScope)
+            ):
                 existing.redefined.append(node)
 
         if value.name in self.scope:

--- a/pyflakes/test/test_imports.py
+++ b/pyflakes/test/test_imports.py
@@ -961,6 +961,28 @@ class Test(TestCase):
                 pass
         ''')
 
+    def test_importNotRedefinedByClassMethod(self):
+        """
+        Methods are bound in the class namespace, not the module namespace.
+        """
+        self.flakes('''
+        import bar
+
+        class Foo:
+            def bar(self):
+                pass
+        ''', m.UnusedImport)
+
+        self.flakes('''
+        import bar
+
+        class Foo:
+            def bar(self):
+                pass
+
+        coffee = bar.Espresso()
+        ''')
+
     def test_futureImport(self):
         """__future__ is special."""
         self.flakes('from __future__ import division')


### PR DESCRIPTION
Fixes #268.

This prevents a binding created in a class namespace from being recorded as a redefinition of an import from an outer scope. A method name such as `Foo.bar` does not rebind the module-level `bar` import, so Pyflakes should still report the import as unused when it is otherwise unused, but should not additionally emit `RedefinedWhileUnused`.

The new regression test covers both cases from the issue:

- an otherwise-unused import with a same-named class method reports only `UnusedImport`
- using the imported module after the class remains clean

Tests:

- `python -m pytest pyflakes/test/test_imports.py::Test::test_importNotRedefinedByClassMethod -q`
- `python -m pytest pyflakes/test/test_imports.py -q`
- `python -m pytest -q`
- `git diff --check`