### PR TITLE
Add tests for walrus operator in comprehensions (fixes #843)

### DIFF
--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -1810,6 +1810,38 @@ class TestUnusedAssignment(TestCase):
             print(z)
         ''')
 
+    def test_assign_expr_pep572_partial_sums(self):
+        """Test PEP 572 partial sums example (issue #843)."""
+        self.flakes('''
+        def cumulative_sum(values):
+            total = 0
+            return [total := total + v for v in values]
+        ''')
+
+    def test_assign_expr_set_comprehension(self):
+        """Test walrus operator in set comprehension with outer variable."""
+        self.flakes('''
+        def f(values):
+            total = 0
+            return {total := total + v for v in values}
+        ''')
+
+    def test_assign_expr_generator_expression(self):
+        """Test walrus operator in generator expression with outer variable."""
+        self.flakes('''
+        def f(values):
+            total = 0
+            return list(total := total + v for v in values)
+        ''')
+
+    def test_assign_expr_nested_comprehension(self):
+        """Test walrus operator in nested comprehension with outer variable."""
+        self.flakes('''
+        def f(values):
+            total = 0
+            return [[total := total + v for v in row] for row in values]
+        ''')
+
 
 class TestStringFormatting(TestCase):
 


### PR DESCRIPTION
## Summary

Add test cases for PEP 572 assignment expressions in comprehensions where the walrus operator reassigns an outer scope variable.

Fixes #843

## Changes

Added 4 new test cases for walrus operator (`:=`) in comprehensions:

1. **`test_assign_expr_pep572_partial_sums`** - The exact PEP 572 partial sums example from the issue:
   ```python
   def cumulative_sum(values):
       total = 0
       return [total := total + v for v in values]
   ```

2. **`test_assign_expr_set_comprehension`** - Walrus in set comprehension with outer variable

3. **`test_assign_expr_generator_expression`** - Walrus in generator expression with outer variable

4. **`test_assign_expr_nested_comprehension`** - Walrus in nested comprehension with outer variable

## Background

The false positive F841 for walrus operators was already fixed in commit b1f8362 ("allow assignment expressions to redefine outer names"). However, there was no specific test coverage for the PEP 572 partial sums pattern reported in issue #843. These tests ensure the fix works correctly across all comprehension types.