### PR TITLE
fix: false positive redefinition warning for methods with same name as imports

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -993,7 +993,10 @@ class Checker:
                 if isinstance(scope, (ClassScope, FunctionScope)):
                     scope.indirect_assignments.pop(value.name, None)
 
-            elif isinstance(existing, Importation) and value.redefines(existing):
+            elif (isinstance(existing, Importation) and
+                    value.redefines(existing) and
+                    not (isinstance(self.scope, ClassScope) and
+                         scope is not self.scope)):
                 existing.redefined.append(node)
 
         if value.name in self.scope:

--- a/pyflakes/test/test_imports.py
+++ b/pyflakes/test/test_imports.py
@@ -709,6 +709,31 @@ class Test(TestCase):
                 fu
         ''', m.UndefinedName)
 
+    def test_methodWithSameNameAsImport(self):
+        """A method with the same name as an import should not cause false
+        positive redefinition warnings. The method is in the class scope,
+        while the import is in the module scope - they are separate namespaces.
+        """
+        # Import is unused - should report UnusedImport only
+        self.flakes('''
+        import bar
+
+        class Foo:
+            def bar(self):
+                pass
+        ''', m.UnusedImport)
+
+        # Import is used - no warnings
+        self.flakes('''
+        import bar
+
+        class Foo:
+            def bar(self):
+                pass
+
+        x = bar.Espresso()
+        ''')
+
     def test_nestedFunctionsNestScope(self):
         self.flakes('''
         def a():


### PR DESCRIPTION
## Description

This PR fixes issue #268 where pyflakes incorrectly reports a false positive 'redefinition of unused import' warning when a method inside a class has the same name as a module-level import.

### Problem

When you have code like:



Pyflakes incorrectly reports:
- 
- 

The second warning is a false positive because the method  inside class  is in the class scope, while the import  is in the module scope - they are separate namespaces.

### Root Cause

In  (checker.py line 996-997), when a method is defined inside a class with the same name as an import in a parent scope, pyflakes walks up the scope stack and finds the import in the ModuleScope. It then treats the method definition as 'redefining' the import, even though they're in completely different namespaces.

### Fix

Modified the condition in  to skip adding to  when:
- The definition is in a 
- The import is in a parent scope (not the same scope)

This preserves the correct behavior for nested function scopes where shadowing an import should still trigger the warning.

### Changes

1. **pyflakes/checker.py**: Added check to skip redefinition when definition is in ClassScope and import is in parent scope
2. **pyflakes/test/test_imports.py**: Added test case  to verify the fix

### Testing

All existing tests pass (733 passed, 19 skipped).

Fixes #268