### PR TITLE
Add tests for walrus operator in comprehensions (fixes #843)

### DIFF
--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -1810,6 +1810,47 @@ class TestUnusedAssignment(TestCase):
             print(z)
         ''')
 
+    def test_assign_expr_partial_sums_pep572(self):
+        """Test PEP 572 partial sums example (issue #843)."""
+        self.flakes('''
+        def cumulative_sum(values):
+            total = 0
+            return [total := total + v for v in values]
+        ''')
+
+    def test_assign_expr_partial_sums_used_after(self):
+        """Test walrus-assigned variable used after comprehension."""
+        self.flakes('''
+        def cumulative_sum(values):
+            total = 0
+            result = [total := total + v for v in values]
+            return total, result
+        ''')
+
+    def test_assign_expr_walrus_in_set_comp(self):
+        """Test walrus operator in set comprehension."""
+        self.flakes('''
+        def f():
+            total = 0
+            return {total := total + x for x in range(5)}
+        ''')
+
+    def test_assign_expr_walrus_in_generator(self):
+        """Test walrus operator in generator expression."""
+        self.flakes('''
+        def f():
+            total = 0
+            return list(total := total + x for x in range(5))
+        ''')
+
+    def test_assign_expr_walrus_in_dict_comp(self):
+        """Test walrus operator in dict comprehension."""
+        self.flakes('''
+        def f():
+            total = 0
+            return {x: (total := total + x) for x in range(5)}
+        ''')
+
 
 class TestStringFormatting(TestCase):
 


### PR DESCRIPTION
## Summary

This PR adds test cases for PEP 572 assignment expressions (walrus operator `:=`) in various comprehension types to prevent regression of false positive F841 (Unused variable) warnings.

## Background

Issue #843 reported a false positive F841 warning when using the walrus operator in a list comprehension:

```python
def cumulative_sum(values):
    total = 0
    return [total := total + v for v in values]
```

The false positive was already fixed by commit b1f8362 ("allow assignment expressions to redefine outer names"), but there were no test cases covering this specific PEP 572 pattern. This PR adds those missing tests.

## Tests Added

- `test_assign_expr_partial_sums_pep572`: The exact PEP 572 partial sums example from issue #843
- `test_assign_expr_partial_sums_used_after`: Walrus-assigned variable used after comprehension
- `test_assign_expr_walrus_in_set_comp`: Walrus operator in set comprehension
- `test_assign_expr_walrus_in_generator`: Walrus operator in generator expression
- `test_assign_expr_walrus_in_dict_comp`: Walrus operator in dict comprehension

All 736 tests pass (19 skipped).

Closes #843