### PR TITLE
Report 'await' outside async functions

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,3 +1,5 @@
+- Report ``await`` used outside an ``async def`` function (See GH-818)
+
 3.4.0 (2025-06-20)
 
 - Add support for python 3.14

--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -824,8 +824,8 @@ class Checker:
         return self.scopeStack[-1]
 
     @contextlib.contextmanager
-    def in_scope(self, cls):
-        self.scopeStack.append(cls())
+    def in_scope(self, cls, *args, **kwargs):
+        self.scopeStack.append(cls(*args, **kwargs))
         try:
             yield
         finally:
@@ -1959,7 +1959,7 @@ class Checker:
             self.handleNode(deco, node)
 
         with self._type_param_scope(node):
-            self.LAMBDA(node, is_async=isinstance(node, ast.AsyncFunctionDef))
+            self.LAMBDA(node)
 
         self.addBinding(node, FunctionDefinition(node.name, node))
         # doctest does not process doctest within a doctest,
@@ -1971,7 +1971,7 @@ class Checker:
 
     ASYNCFUNCTIONDEF = FUNCTIONDEF
 
-    def LAMBDA(self, node, is_async=False):
+    def LAMBDA(self, node):
         args = []
         annotations = []
 
@@ -2007,9 +2007,12 @@ class Checker:
         for default in defaults:
             self.handleNode(default, node)
 
+        # FunctionScope is reused for both `def`/`async def` and lambda.
+        # Only AsyncFunctionDef is async; lambdas never are.
+        is_async = isinstance(node, ast.AsyncFunctionDef)
+
         def runFunction():
-            with self.in_scope(FunctionScope):
-                self.scope.is_async = is_async
+            with self.in_scope(FunctionScope, is_async=is_async):
                 self.handleChildren(
                     node,
                     omit=('decorator_list', 'returns', 'type_params'),

--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -537,17 +537,19 @@ class FunctionScope(Scope):
     I represent a name scope for a function.
 
     @ivar globals: Names declared 'global' in this function.
+    @ivar is_async: True when this scope belongs to an ``async def``.
     """
     usesLocals = False
     alwaysUsed = {'__tracebackhide__', '__traceback_info__',
                   '__traceback_supplement__', '__debuggerskip__'}
 
-    def __init__(self):
+    def __init__(self, is_async=False):
         super().__init__()
         # Simplify: manage the special locals as globals
         self.globals = self.alwaysUsed.copy()
         # {name: node}
         self.indirect_assignments = {}
+        self.is_async = is_async
 
     def unused_assignments(self):
         """
@@ -1934,14 +1936,30 @@ class Checker:
 
         self.handleNode(node.value, node)
 
-    AWAIT = YIELDFROM = YIELD
+    YIELDFROM = YIELD
+
+    def AWAIT(self, node):
+        # await is only legal inside an async function (including nested
+        # comprehensions therein). See https://github.com/PyCQA/pyflakes/issues/818
+        in_async_function = False
+        for scope in reversed(self.scopeStack):
+            if isinstance(scope, FunctionScope):
+                in_async_function = scope.is_async
+                break
+            if isinstance(scope, (ClassScope, ModuleScope)):
+                break
+        if not in_async_function:
+            self.report(messages.AwaitOutsideAsyncFunction, node)
+            return
+
+        self.handleNode(node.value, node)
 
     def FUNCTIONDEF(self, node):
         for deco in node.decorator_list:
             self.handleNode(deco, node)
 
         with self._type_param_scope(node):
-            self.LAMBDA(node)
+            self.LAMBDA(node, is_async=isinstance(node, ast.AsyncFunctionDef))
 
         self.addBinding(node, FunctionDefinition(node.name, node))
         # doctest does not process doctest within a doctest,
@@ -1953,7 +1971,7 @@ class Checker:
 
     ASYNCFUNCTIONDEF = FUNCTIONDEF
 
-    def LAMBDA(self, node):
+    def LAMBDA(self, node, is_async=False):
         args = []
         annotations = []
 
@@ -1991,6 +2009,7 @@ class Checker:
 
         def runFunction():
             with self.in_scope(FunctionScope):
+                self.scope.is_async = is_async
                 self.handleChildren(
                     node,
                     omit=('decorator_list', 'returns', 'type_params'),

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -193,6 +193,13 @@ class YieldOutsideFunction(Message):
 
 # For whatever reason, Python gives different error messages for these two. We
 # match the Python error message exactly.
+class AwaitOutsideAsyncFunction(Message):
+    """
+    Indicates an await expression outside of an async function/method.
+    """
+    message = '\'await\' outside async function'
+
+
 class ContinueOutsideLoop(Message):
     """
     Indicates a continue statement outside of a while or for loop.

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -1985,6 +1985,41 @@ class TestAsyncStatements(TestCase):
             await db.fetch('SELECT ...')
         ''')
 
+    def test_awaitInNonAsyncFunction(self):
+        """
+        await inside a plain def is invalid; report it (issue #818).
+        """
+        self.flakes('''
+        async def foo():
+            pass
+
+        def bar():
+            await foo()
+        ''', m.AwaitOutsideAsyncFunction)
+
+    def test_awaitAtModuleLevel(self):
+        self.flakes('''
+        await 1
+        ''', m.AwaitOutsideAsyncFunction)
+
+    def test_awaitInClassBody(self):
+        self.flakes('''
+        class C:
+            await 1
+        ''', m.AwaitOutsideAsyncFunction)
+
+    def test_awaitInListCompOutsideAsync(self):
+        self.flakes('''
+        y = []
+        [await x for x in y]
+        ''', m.AwaitOutsideAsyncFunction)
+
+    def test_awaitInListCompInsideAsync(self):
+        self.flakes('''
+        async def f(y):
+            return [await x for x in y]
+        ''')
+
     def test_asyncDefUndefined(self):
         self.flakes('''
         async def bar():


### PR DESCRIPTION
`await` is only valid inside `async def`. pyflakes already warns for `yield` / `return` outside functions, but `AWAIT` was aliased to the yield handler, so `await` inside a plain `def` produced no message.

Track async function scopes and report `await` outside them.

Fixes #818
