### PR TITLE
add new errors for lazy imports

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -275,9 +275,10 @@ class Importation(Definition):
     @type fullName: C{str}
     """
 
-    def __init__(self, name, source, full_name=None):
+    def __init__(self, name, source, full_name=None, *, is_lazy: int):
         self.fullName = full_name or name
         self.redefined = []
+        self.is_lazy = is_lazy
         super().__init__(name, source)
 
     def redefines(self, other):
@@ -291,13 +292,17 @@ class Importation(Definition):
         return not self.fullName.split('.')[-1] == self.name
 
     @property
+    def _lazy_s(self) -> str:
+        return 'lazy ' if self.is_lazy else ''
+
+    @property
     def _alias_s(self) -> str:
         return f' as {self.name}' if self._has_alias() else ''
 
     @property
     def source_statement(self):
         """Generate a source statement equivalent to the import."""
-        return f'import {self.fullName}{self._alias_s}'
+        return f'{self._lazy_s}import {self.fullName}{self._alias_s}'
 
     def __str__(self):
         """Return import full name with alias."""
@@ -321,11 +326,11 @@ class SubmoduleImportation(Importation):
     name is also the same, to avoid false positives.
     """
 
-    def __init__(self, name, source):
+    def __init__(self, name, source, *, is_lazy: int):
         # A dot should only appear in the name when it is a submodule import
         assert '.' in name and (not source or isinstance(source, ast.Import))
         package_name = name.split('.')[0]
-        super().__init__(package_name, source)
+        super().__init__(package_name, source, is_lazy=is_lazy)
         self.fullName = name
 
     def redefines(self, other):
@@ -335,7 +340,7 @@ class SubmoduleImportation(Importation):
 
     @property
     def source_statement(self):
-        return f'import {self.fullName}'
+        return f'{self._lazy_s}import {self.fullName}'
 
     def __str__(self):
         return self.fullName
@@ -343,7 +348,7 @@ class SubmoduleImportation(Importation):
 
 class ImportationFrom(Importation):
 
-    def __init__(self, name, source, module, real_name=None):
+    def __init__(self, name, source, module, real_name=None, *, is_lazy: int):
         self.module = module
         self.real_name = real_name or name
 
@@ -352,11 +357,11 @@ class ImportationFrom(Importation):
         else:
             full_name = module + '.' + self.real_name
 
-        super().__init__(name, source, full_name)
+        super().__init__(name, source, full_name, is_lazy=is_lazy)
 
     @property
     def source_statement(self):
-        return f'from {self.module} import {self.real_name}{self._alias_s}'
+        return f'{self._lazy_s}from {self.module} import {self.real_name}{self._alias_s}'
 
     def __str__(self):
         """Return import full name with alias."""
@@ -367,7 +372,7 @@ class StarImportation(Importation):
     """A binding created by a 'from x import *' statement."""
 
     def __init__(self, name, source):
-        super().__init__('*', source)
+        super().__init__('*', source, is_lazy=False)
         # Each star importation needs a unique name, and
         # may not be the module name otherwise it will be deemed imported
         self.name = name + '.*'
@@ -393,7 +398,7 @@ class FutureImportation(ImportationFrom):
     """
 
     def __init__(self, name, source, scope):
-        super().__init__(name, source, '__future__')
+        super().__init__(name, source, '__future__', is_lazy=False)
         self.used = (scope, source)
 
 
@@ -547,7 +552,11 @@ class TypeScope(Scope):
     pass
 
 
-class GeneratorScope(Scope):
+class ComprehensionScope(Scope):
+    pass
+
+
+class GeneratorScope(ComprehensionScope):
     pass
 
 
@@ -662,6 +671,7 @@ class AnnotationState:
     NONE = 0
     STRING = 1
     BARE = 2
+    TYPE_ALIAS = 3
 
 
 def in_annotation(func):
@@ -689,10 +699,10 @@ class Checker:
         ast.FunctionDef: FunctionScope,
         ast.AsyncFunctionDef: FunctionScope,
         ast.Lambda: FunctionScope,
-        ast.ListComp: GeneratorScope,
-        ast.SetComp: GeneratorScope,
+        ast.ListComp: ComprehensionScope,
+        ast.SetComp: ComprehensionScope,
         ast.GeneratorExp: GeneratorScope,
-        ast.DictComp: GeneratorScope,
+        ast.DictComp: ComprehensionScope,
     }
 
     nodeDepth = 0
@@ -981,7 +991,7 @@ class Checker:
                 scope = next(
                     scope
                     for scope in reversed(self.scopeStack)
-                    if not isinstance(scope, GeneratorScope)
+                    if not isinstance(scope, ComprehensionScope)
                 )
                 if value.name in scope and isinstance(scope[value.name], Annotation):
                     # re-assignment to name that was previously only an annotation
@@ -1030,9 +1040,13 @@ class Checker:
         # - type annotations (for generics, etc.)
         can_access_class_vars = None
         importStarred = None
+        func_depth = 0
 
         # try enclosing function scopes and global scope
         for scope in reversed(self.scopeStack):
+            if isinstance(scope, (FunctionScope, GeneratorScope)):
+                func_depth += 1
+
             if isinstance(scope, ClassScope):
                 if name == '__class__':
                     return
@@ -1047,10 +1061,19 @@ class Checker:
                 scope[name].used = (self.scope, node)
                 continue
 
-            if name == 'print' and isinstance(binding, Builtin):
+            elif name == 'print' and isinstance(binding, Builtin):
                 if (isinstance(parent, ast.BinOp) and
                         isinstance(parent.op, ast.RShift)):
                     self.report(messages.InvalidPrintSyntax, node)
+            elif (
+                    isinstance(binding, Importation) and
+                    binding.is_lazy and
+                    func_depth == 0 and (
+                        self._in_annotation == AnnotationState.NONE or
+                        self._in_annotation == AnnotationState.TYPE_ALIAS
+                    )
+            ):
+                self.report(messages.EagerUseOfLazyImport, node, name, binding.source)
 
             try:
                 scope[name].used = (self.scope, node)
@@ -1073,7 +1096,7 @@ class Checker:
 
             if can_access_class_vars is not False:
                 can_access_class_vars = isinstance(
-                    scope, (TypeScope, GeneratorScope),
+                    scope, (TypeScope, ComprehensionScope),
                 )
 
         if importStarred:
@@ -1840,9 +1863,17 @@ class Checker:
     NONLOCAL = GLOBAL
 
     def GENERATOREXP(self, node):
-        with self.in_scope(GeneratorScope):
-            # handle generators before the comprehension target
-            for gen in node.generators:
+        # the first generator's iterable is eagerly executed in parent scope
+        self.handleNode(node.generators[0].iter, node.generators[0])
+
+        if isinstance(node, ast.GeneratorExp):
+            scope_tp = GeneratorScope
+        else:
+            scope_tp = ComprehensionScope
+
+        with self.in_scope(scope_tp):
+            self.handleChildren(node.generators[0], omit=('iter',))
+            for gen in node.generators[1:]:
                 self.handleNode(gen, node)
             self.handleChildren(node, omit=('generators',))
 
@@ -2014,7 +2045,8 @@ class Checker:
         if node.value:
             # If the annotation is `TypeAlias`, handle the *value* as an annotation.
             if _is_typing(node.annotation, 'TypeAlias', self.scopeStack):
-                self.handleAnnotation(node.value, node)
+                with self._enter_annotation(AnnotationState.TYPE_ALIAS):
+                    self.handleNode(node.value, node)
             else:
                 self.handleNode(node.value, node)
         self.handleNode(node.target, node)
@@ -2050,12 +2082,20 @@ class Checker:
     LIST = TUPLE
 
     def IMPORT(self, node):
+        lazy = sys.version_info >= (3, 15) and node.is_lazy
+        if lazy and not isinstance(self.scope, ModuleScope):
+            self.report(messages.LazyImportNotAtModuleScope, node)
+            return
+
         for alias in node.names:
             if '.' in alias.name and not alias.asname:
-                importation = SubmoduleImportation(alias.name, node)
+                importation = SubmoduleImportation(
+                    alias.name, node,
+                    is_lazy=lazy,
+                )
             else:
                 name = alias.asname or alias.name
-                importation = Importation(name, node, alias.name)
+                importation = Importation(name, node, alias.name, is_lazy=lazy)
             self.addBinding(node, importation)
 
     def IMPORTFROM(self, node):
@@ -2064,6 +2104,11 @@ class Checker:
                 self.report(messages.LateFutureImport, node)
         else:
             self.futuresAllowed = False
+
+        lazy = sys.version_info >= (3, 15) and node.is_lazy
+        if lazy and not isinstance(self.scope, ModuleScope):
+            self.report(messages.LazyImportNotAtModuleScope, node)
+            return
 
         module = ('.' * node.level) + (node.module or '')
 
@@ -2078,16 +2123,20 @@ class Checker:
                     self.annotationsFutureEnabled = True
             elif alias.name == '*':
                 if not isinstance(self.scope, ModuleScope):
-                    self.report(messages.ImportStarNotPermitted,
-                                node, module)
+                    self.report(messages.ImportStarNotPermitted, node, module)
+                    continue
+                elif sys.version_info >= (3, 15) and node.is_lazy:
+                    self.report(messages.LazyImportStarNotPermitted, node, module)
                     continue
 
                 self.scope.importStarred = True
                 self.report(messages.ImportStarUsed, node, module)
                 importation = StarImportation(module, node)
             else:
-                importation = ImportationFrom(name, node,
-                                              module, alias.name)
+                importation = ImportationFrom(
+                    name, node, module, alias.name,
+                    is_lazy=lazy,
+                )
             self.addBinding(node, importation)
 
     def TRY(self, node):

--- a/pyflakes/messages.py
+++ b/pyflakes/messages.py
@@ -360,3 +360,23 @@ class PercentFormatExpectedSequence(Message):
 
 class PercentFormatStarRequiresSequence(Message):
     message = "'...' %% ... `*` specifier requires sequence"
+
+
+class EagerUseOfLazyImport(Message):
+    message = 'eager use of lazily imported %r from line %r'
+
+    def __init__(self, filename, loc, name, orig_loc):
+        Message.__init__(self, filename, loc)
+        self.message_args = (name, orig_loc.lineno)
+
+
+class LazyImportStarNotPermitted(Message):
+    message = "'lazy from %s import *' is not allowed"
+
+    def __init__(self, filename, loc, modname):
+        Message.__init__(self, filename, loc)
+        self.message_args = (modname,)
+
+
+class LazyImportNotAtModuleScope(Message):
+    message = 'lazy import must be at module scope'

--- a/pyflakes/test/test_imports.py
+++ b/pyflakes/test/test_imports.py
@@ -14,68 +14,68 @@ from pyflakes.test.harness import TestCase, skip, skipIf
 class TestImportationObject(TestCase):
 
     def test_import_basic(self):
-        binding = Importation('a', None, 'a')
+        binding = Importation('a', None, 'a', is_lazy=False)
         assert binding.source_statement == 'import a'
         assert str(binding) == 'a'
 
     def test_import_as(self):
-        binding = Importation('c', None, 'a')
+        binding = Importation('c', None, 'a', is_lazy=False)
         assert binding.source_statement == 'import a as c'
         assert str(binding) == 'a as c'
 
     def test_import_submodule(self):
-        binding = SubmoduleImportation('a.b', None)
+        binding = SubmoduleImportation('a.b', None, is_lazy=False)
         assert binding.source_statement == 'import a.b'
         assert str(binding) == 'a.b'
 
     def test_import_submodule_as(self):
         # A submodule import with an as clause is not a SubmoduleImportation
-        binding = Importation('c', None, 'a.b')
+        binding = Importation('c', None, 'a.b', is_lazy=False)
         assert binding.source_statement == 'import a.b as c'
         assert str(binding) == 'a.b as c'
 
     def test_import_submodule_as_source_name(self):
-        binding = Importation('a', None, 'a.b')
+        binding = Importation('a', None, 'a.b', is_lazy=False)
         assert binding.source_statement == 'import a.b as a'
         assert str(binding) == 'a.b as a'
 
     def test_importfrom_relative(self):
-        binding = ImportationFrom('a', None, '.', 'a')
+        binding = ImportationFrom('a', None, '.', 'a', is_lazy=False)
         assert binding.source_statement == 'from . import a'
         assert str(binding) == '.a'
 
     def test_importfrom_relative_parent(self):
-        binding = ImportationFrom('a', None, '..', 'a')
+        binding = ImportationFrom('a', None, '..', 'a', is_lazy=False)
         assert binding.source_statement == 'from .. import a'
         assert str(binding) == '..a'
 
     def test_importfrom_relative_with_module(self):
-        binding = ImportationFrom('b', None, '..a', 'b')
+        binding = ImportationFrom('b', None, '..a', 'b', is_lazy=False)
         assert binding.source_statement == 'from ..a import b'
         assert str(binding) == '..a.b'
 
     def test_importfrom_relative_with_module_as(self):
-        binding = ImportationFrom('c', None, '..a', 'b')
+        binding = ImportationFrom('c', None, '..a', 'b', is_lazy=False)
         assert binding.source_statement == 'from ..a import b as c'
         assert str(binding) == '..a.b as c'
 
     def test_importfrom_member(self):
-        binding = ImportationFrom('b', None, 'a', 'b')
+        binding = ImportationFrom('b', None, 'a', 'b', is_lazy=False)
         assert binding.source_statement == 'from a import b'
         assert str(binding) == 'a.b'
 
     def test_importfrom_submodule_member(self):
-        binding = ImportationFrom('c', None, 'a.b', 'c')
+        binding = ImportationFrom('c', None, 'a.b', 'c', is_lazy=False)
         assert binding.source_statement == 'from a.b import c'
         assert str(binding) == 'a.b.c'
 
     def test_importfrom_member_as(self):
-        binding = ImportationFrom('c', None, 'a', 'b')
+        binding = ImportationFrom('c', None, 'a', 'b', is_lazy=False)
         assert binding.source_statement == 'from a import b as c'
         assert str(binding) == 'a.b as c'
 
     def test_importfrom_submodule_member_as(self):
-        binding = ImportationFrom('d', None, 'a.b', 'c')
+        binding = ImportationFrom('d', None, 'a.b', 'c', is_lazy=False)
         assert binding.source_statement == 'from a.b import c as d'
         assert str(binding) == 'a.b.c as d'
 
@@ -93,6 +93,18 @@ class TestImportationObject(TestCase):
         binding = FutureImportation('print_function', None, None)
         assert binding.source_statement == 'from __future__ import print_function'
         assert str(binding) == '__future__.print_function'
+
+    def test_lazy_import(self):
+        binding = Importation('a', None, 'a', is_lazy=True)
+        assert binding.source_statement == 'lazy import a'
+
+    def test_lazy_submodule_import(self):
+        binding = SubmoduleImportation('a.b', None, is_lazy=True)
+        assert binding.source_statement == 'lazy import a.b'
+
+    def test_lazy_importfrom(self):
+        binding = ImportationFrom('b', None, 'a', 'b', is_lazy=True)
+        assert binding.source_statement == 'lazy from a import b'
 
     def test_unusedImport_underscore(self):
         """

--- a/pyflakes/test/test_lazy_imports.py
+++ b/pyflakes/test/test_lazy_imports.py
@@ -1,0 +1,63 @@
+from sys import version_info
+
+from pyflakes import messages as m
+from pyflakes.test.harness import TestCase, skipIf
+
+
+@skipIf(version_info < (3, 15), 'new in Python 3.15')
+class Test(TestCase):
+    def test_unused_lazy_imports(self):
+        self.flakes('''
+        lazy import x
+        lazy from y import z
+        ''', m.UnusedImport, m.UnusedImport)
+
+    def test_lazy_star_import_not_allowed(self):
+        self.flakes('''
+        lazy from x import *
+        ''', m.LazyImportStarNotPermitted)
+
+    def test_lazy_import_not_at_module_scope(self):
+        self.flakes('''
+        def f():
+            lazy import x
+        class C:
+            lazy from y import z
+        ''', m.LazyImportNotAtModuleScope, m.LazyImportNotAtModuleScope)
+
+    def test_lazy_imports_eager_use_ok(self):
+        self.flakes('''
+        lazy from x import y
+
+        x: y = ...                 # ok in annotations
+        type q = y                 # ok in type aliases
+        def f1(u: y) -> y: ...     # ok in function annotations
+        def f2(): print(y)         # ok in nested scope
+        x = (y for _ in [])        # ok not in generator iter
+        ''')
+
+    def test_lazy_imports_eager_use_error(self):
+        self.flakes('''
+        lazy from x import y
+        z = y                     # module scope
+
+        class C:
+            z = y                 # class scope
+
+        match y:                  # match expression
+            case y.attr: pass     # case attribute
+
+        (_ for _ in y)            # generator expression iterable
+
+        [y for _ in [...]]        # evaluated comprehensions
+        {y for _ in [...]}        # evaluated comprehensions
+        {0: y for _ in [...]}     # evaluated comprehensions
+
+        ''', *([m.EagerUseOfLazyImport] * 8))
+
+    def test_lazy_imports_eager_use_in_type_alias(self):
+        self.flakes('''
+        from typing import TypeAlias
+        lazy from x import y
+        alias: TypeAlias = y      # evaluated eagerly
+        ''', m.EagerUseOfLazyImport)

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -1811,13 +1811,6 @@ class TestUnusedAssignment(TestCase):
         ''')
 
     @skipIf(version_info < (3, 15), 'new in Python 3.15')
-    def test_unused_lazy_imports(self):
-        self.flakes('''
-        lazy import x
-        lazy from y import z
-        ''', m.UnusedImport, m.UnusedImport)
-
-    @skipIf(version_info < (3, 15), 'new in Python 3.15')
     def test_reassigned_in_comprehension_unpacking(self):
         self.flakes('''
         x = 1


### PR DESCRIPTION
- error if a lazy import is eagerly used at the module scope
- error for `lazy from ... import *`
- (no new code needed) error for `lazy from __future__ import ...`
- error for `lazy` import not at module scope